### PR TITLE
[fixes #55] added support for enableAdvertisingIdCollection(boolean) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+# IDE
+.idea
+*.iml

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -29,6 +29,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
     public static final String SET_USER_ID = "setUserId";
     public static final String DEBUG_MODE = "debugMode";
+    public static final String ENABLE_AD_ID_COLLECTION = "enableAdvertisingIdCollection";
 
     public Boolean trackerStarted = false;
     public Boolean debugModeEnabled = false;
@@ -103,6 +104,9 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             this.setUserId(userId, callbackContext);
         } else if (DEBUG_MODE.equals(action)) {
             this.debugMode(callbackContext);
+        } else if(ENABLE_AD_ID_COLLECTION.equals(action)) {
+            Boolean isEnabled = args.getBoolean(0);
+            this.enableAdIdCollection(isEnabled, callbackContext);
         }
         return false;
     }
@@ -271,5 +275,16 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         Tracker tracker = GoogleAnalytics.getInstance(this.cordova.getActivity()).getDefaultTracker();
         tracker.set("&uid", userId);
         callbackContext.success("Set user id" + userId);
+    }
+
+    private void enableAdIdCollection(Boolean isEnabled, CallbackContext callbackContext) {
+        if (! trackerStarted ) {
+            callbackContext.error("Tracker not started");
+            return;
+        }
+
+        Tracker tracker = GoogleAnalytics.getInstance(this.cordova.getActivity()).getDefaultTracker();
+        tracker.enableAdvertisingIdCollection(isEnabled);
+        callbackContext.success((isEnabled ? "En" : "Dis")+ "abled ad id collection for Display Advertisement");
     }
 }

--- a/ios/UniversalAnalyticsPlugin.h
+++ b/ios/UniversalAnalyticsPlugin.h
@@ -14,6 +14,7 @@
 - (void) startTrackerWithId: (CDVInvokedUrlCommand*)command;
 - (void) setUserId: (CDVInvokedUrlCommand*)command;
 - (void) debugMode: (CDVInvokedUrlCommand*)command;
+- (void) enableAdvertisingIdCollection: (CDVInvokedUrlCommand*)command;
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command;
 - (void) trackEvent: (CDVInvokedUrlCommand*)command;
 - (void) trackTiming: (CDVInvokedUrlCommand*)command;

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -67,6 +67,24 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) enableAdvertisingIdCollection: (CDVInvokedUrlCommand*)command
+{
+  CDVPluginResult* pluginResult = nil;
+  bool isEnabled = [[command.arguments objectAtIndex:0] boolValue];
+
+  if ( ! _trackerStarted) {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Tracker not started"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    return;
+  }
+
+  id<GAITracker> tracker = [[GAI sharedInstance] defaultTracker];
+  tracker.allowIDFACollection = isEnabled ? YES : NO;
+
+  pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -13,6 +13,14 @@ UniversalAnalyticsPlugin.prototype.debugMode = function(success, error) {
   cordova.exec(success, error, 'UniversalAnalytics', 'debugMode', []);
 };
 
+/**
+ * Enable/Disable ad id collection to support display advertisement
+ * @see https://support.google.com/analytics/answer/2444872/
+ */
+UniversalAnalyticsPlugin.prototype.enableAdvertisingIdCollection = function(enabled, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'enableAdvertisingIdCollection', [enabled]);
+};
+
 UniversalAnalyticsPlugin.prototype.trackView = function(screen, success, error) {
   cordova.exec(success, error, 'UniversalAnalytics', 'trackView', [screen]);
 };


### PR DESCRIPTION
PR for https://github.com/danwilson/google-analytics-plugin/issues/55 to support display advertisement features as described in https://support.google.com/analytics/answer/2444872.

Please check the IOS part, since I never touched any IOS project before. Also, what else would be needed to get started with this? The docs stated something about:

> To use Google Analytics advertising features requires that you collect the IDFA (Identifier for Advertisers). To enable IDFA collection, link the libAdIdAccess.a and AdSupport.framework libraries to your application and set the allowIDFACollection property to YES on each tracker for which you want to enable advertising features.

I added the `libAdIdAccess.a` manually in the XCode build, and it seemingly works. I will have to verify with data after another 24 hours. Is there any way to add this file automatically during build?