### PR TITLE
fix(success callback is not called in the addCustomDimension method)

### DIFF
--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -122,6 +122,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
     private void addCustomDimension(String key, String value, CallbackContext callbackContext) {
         if (null != key && key.length() > 0 && null != value && value.length() > 0) {
             customDimensions.put(key, value);
+            callbackContext.success("custom dimension started");
         } else {
             callbackContext.error("Expected non-empty string arguments.");
         }


### PR DESCRIPTION
I noticed that when calling the method UniversalAnalyticsPlugin.prototype.addCustomDimension in analytics.js, the function passed in as the success parameter wasn't getting called despite the resulting call made to the java class being sound. This pull request fixes that. Please let me know if you have any questions, and thanks very much.