### PR TITLE
Rename 'analytics' global to 'ga'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,51 +38,51 @@ Windows Phone users have to manually add the [Google Analytics SDK for Windows 8
 
 #JavaScript Usage
 In your 'deviceready' handler, set up your Analytics tracker:
-* `window.analytics.startTrackerWithId('UA-XXXX-YY')` where UA-XXXX-YY is your Google Analytics Mobile App property
+* `window.ga.startTrackerWithId('UA-XXXX-YY')` where UA-XXXX-YY is your Google Analytics Mobile App property
 
 To track a Screen (PageView):
-* `window.analytics.trackView('Screen Title')`
+* `window.ga.trackView('Screen Title')`
 
 To track an Event:
-* `window.analytics.trackEvent('Category', 'Action', 'Label', Value)` Label and Value are optional, Value is numeric
+* `window.ga.trackEvent('Category', 'Action', 'Label', Value)` Label and Value are optional, Value is numeric
 
-To track an custom metrics:
-* `window.analytics.trackMetric('key', Value)` Value is optional
+To track custom metrics:
+* `window.ga.trackMetric('key', Value)` Value is optional
 
 To track an Exception:
-* `window.analytics.trackException('Description', Fatal)` where Fatal is boolean
+* `window.ga.trackException('Description', Fatal)` where Fatal is boolean
 
 To track User Timing (App Speed):
-* `window.analytics.trackTiming('Category', IntervalInMilliseconds, 'Variable', 'Label')` where IntervalInMilliseconds is numeric
+* `window.ga.trackTiming('Category', IntervalInMilliseconds, 'Variable', 'Label')` where IntervalInMilliseconds is numeric
 
 To add a Transaction (Ecommerce)
-* `window.analytics.addTransaction('ID', 'Affiliation', Revenue, Tax, Shipping, 'Currency Code')` where Revenue, Tax, and Shipping are numeric
+* `window.ga.addTransaction('ID', 'Affiliation', Revenue, Tax, Shipping, 'Currency Code')` where Revenue, Tax, and Shipping are numeric
 
 To add a Transaction Item (Ecommerce)
-* `window.analytics.addTransactionItem('ID', 'Name', 'SKU', 'Category', Price, Quantity, 'Currency Code')` where Price and Quantity are numeric
+* `window.ga.addTransactionItem('ID', 'Name', 'SKU', 'Category', Price, Quantity, 'Currency Code')` where Price and Quantity are numeric
 
 To add a Custom Dimension
-* `window.analytics.addCustomDimension('Key', 'Value', success, error)`
+* `window.ga.addCustomDimension('Key', 'Value', success, error)`
 * Key should be integer index of the dimension i.e. send `1` instead of `dimension1` for the first custom dimension you are tracking.
 * e.g. `window.analytics.addCustomDimension(1, 'Value', success, error)`
 
 To set a UserId:
-* `window.analytics.setUserId('my-user-id')`
+* `window.ga.setUserId('my-user-id')`
 
 To set a specific app version:
-* `window.analytics.setAppVersion('1.33.7')`
+* `window.ga.setAppVersion('1.33.7')`
 
 To set a anonymize Ip address:
-* `window.analytics.setAnonymizeIp(true)`
+* `window.ga.setAnonymizeIp(true)`
 
 To enabling Advertising Features in Google Analytics allows you to take advantage of Remarketing, Demographics & Interests reports, and more:
-* `window.analytics.setAllowIDFACollection(true)`
+* `window.ga.setAllowIDFACollection(true)`
 
 To enable verbose logging:
-* `window.analytics.debugMode()`
+* `window.ga.debugMode()`
 
 To enable/disable automatic reporting of uncaught exceptions
-* `window.analytics.enableUncaughtExceptionReporting(Enable, success, error)` where Enable is boolean
+* `window.ga.enableUncaughtExceptionReporting(Enable, success, error)` where Enable is boolean
 
 #Installing Without the CLI <a name="nocli"></a>
 Copy the files manually into your project and add the following to your config.xml files:

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,9 @@
   <author>Daniel C. Wilson</author>
   <license>MIT License</license>
   <js-module src="www/analytics.js" name="UniversalAnalytics">
+    <!-- 'analytics' is deprecated, but supported to ease the transition -->
     <clobbers target="analytics" />
+    <clobbers target="ga" />
   </js-module>
 
   <platform name="ios">


### PR DESCRIPTION
To be more consistent with how the web tracker works, and to avoid
conflicts when using the segment.io/analytics.js library at the same
time, I've renamed the global object used by the plugin from 'analytics'
to 'ga'.

This fixes https://github.com/danwilson/google-analytics-plugin/issues/32.

It is a breaking change, so probably requires a major version rev.