### PR TITLE
Add Windows Phone 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ google-analytics-plugin
 Cordova (PhoneGap) 3.0+ Plugin to connect to Google's native Universal Analytics SDK
 
 Prerequisites:
-* A Cordova 3.0+ project for iOS and/or Android
+* A Cordova 3.0+ project for iOS, Android and/or Windows Phone 8
 * A Mobile App property through the Google Analytics Admin Console
 * (Android) Google Play Services SDK installed via [Android SDK Manager](https://developer.android.com/sdk/installing/adding-packages.html)
 
@@ -27,9 +27,11 @@ cordova plugin add com.danielcwilson.plugins.googleanalytics
 
 *Important Note* If the latest versions (0.8.0+) of this plugin are not working for you with Android on Cordova 5.0+, please try the suggestions in [Issues 123](https://github.com/danwilson/google-analytics-plugin/issues/123#issuecomment-151145095). Google Play Services has been very confusing to integrate, but in recent months it has been simplified.  This plugin uses the new simpler way (including it as a framework instead of bundling it which can conflict with other plugins bundling it), but if you previously installed this plugin some old files might still be lingering.
 
-The plugin.xml file will add the Google Analytics SDK files for Android and/or iOS.  Follow [Google's steps](#sdk-files) if you need to update these later.  Also make sure to review the Google Analytics [terms](http://www.google.com/analytics/terms/us.html) and [SDK Policy](https://developers.google.com/analytics/devguides/collection/protocol/policy)
+The plugin.xml file will add the Google Analytics SDK files for Android, iOS and/or Windows Phone 8.  Follow [Google's steps](#sdk-files) if you need to update these later.  Also make sure to review the Google Analytics [terms](http://www.google.com/analytics/terms/us.html) and [SDK Policy](https://developers.google.com/analytics/devguides/collection/protocol/policy)
 
 If you are not using the CLI, follow the steps in the section [Installing Without the CLI](#nocli)
+
+Windows Phone users have to manually add the [Google Analytics SDK for Windows 8 and Windows Phone](https://googleanalyticssdk.codeplex.com/) to your solution. To do this, just open your Cordova solution in Visual Studio, and add the [GoogleAnalyticsSDK package via NuGet](http://nuget.org/packages/GoogleAnalyticsSDK).
 
 #JavaScript Usage
 In your 'deviceready' handler, set up your Analytics tracker:
@@ -77,11 +79,17 @@ Copy the files manually into your project and add the following to your config.x
   <param name="android-package" value="com.danielcwilson.plugins.analytics.UniversalAnalyticsPlugin" />
 </feature>
 ```
+```xml
+<feature name="UniversalAnalytics">
+  <param name="wp-package" value="UniversalAnalyticsPlugin" />
+</feature>
+```
 <a name="sdk-files"></a>
 You also will need to manually add the Google Analytics SDK files:
 * Download the Google Analytics SDK 3.0 for [iOS](https://developers.google.com/analytics/devguides/collection/ios/) and/or [Android](https://developers.google.com/analytics/devguides/collection/android/)
 * For iOS, add the downloaded Google Analytics SDK header files and libraries according to the [Getting Started](https://developers.google.com/analytics/devguides/collection/ios/v3) documentation
 * For Android, add `libGoogleAnalyticsServices.jar` to your Cordova Android project's `/libs` directory and build path
+* For Windows Phone, add the [GoogleAnalyticsSDK package via NuGet](http://nuget.org/packages/GoogleAnalyticsSDK)
 
 #Integrating with Lavaca
 The `lavaca` directory includes a component that can be added to a <a href="http://getlavaca.com">Lavaca</a> project.  It offers a way to use the web `analytics.js` when the app is running in the browser and not packaged as Cordova.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The plugin.xml file will add the Google Analytics SDK files for Android, iOS and
 
 If you are not using the CLI, follow the steps in the section [Installing Without the CLI](#nocli)
 
-Windows Phone users have to manually add the [Google Analytics SDK for Windows 8 and Windows Phone](https://googleanalyticssdk.codeplex.com/) to your solution. To do this, just open your Cordova solution in Visual Studio, and add the [GoogleAnalyticsSDK package via NuGet](http://nuget.org/packages/GoogleAnalyticsSDK). This plugin requires v1.2.12 or higher.
+Windows Phone users have to manually add the [Google Analytics SDK for Windows 8 and Windows Phone](https://googleanalyticssdk.codeplex.com/) to your solution. To do this, just open your Cordova solution in Visual Studio, and add the [GoogleAnalyticsSDK package via NuGet](http://nuget.org/packages/GoogleAnalyticsSDK). This plugin requires v1.3.0 or higher.
 
 #JavaScript Usage
 In your 'deviceready' handler, set up your Analytics tracker:
@@ -58,7 +58,7 @@ To add a Transaction Item (Ecommerce)
 To add a Custom Dimension
 * `window.analytics.addCustomDimension('Key', 'Value', success, error)`
 
-To set a UserId (not currently supported on Windows Phone 8):
+To set a UserId:
 * `window.analytics.setUserId('my-user-id')`
 
 To enable verbose logging:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The plugin.xml file will add the Google Analytics SDK files for Android, iOS and
 
 If you are not using the CLI, follow the steps in the section [Installing Without the CLI](#nocli)
 
-Windows Phone users have to manually add the [Google Analytics SDK for Windows 8 and Windows Phone](https://googleanalyticssdk.codeplex.com/) to your solution. To do this, just open your Cordova solution in Visual Studio, and add the [GoogleAnalyticsSDK package via NuGet](http://nuget.org/packages/GoogleAnalyticsSDK).
+Windows Phone users have to manually add the [Google Analytics SDK for Windows 8 and Windows Phone](https://googleanalyticssdk.codeplex.com/) to your solution. To do this, just open your Cordova solution in Visual Studio, and add the [GoogleAnalyticsSDK package via NuGet](http://nuget.org/packages/GoogleAnalyticsSDK). This plugin requires v1.2.12 or higher.
 
 #JavaScript Usage
 In your 'deviceready' handler, set up your Analytics tracker:
@@ -58,7 +58,7 @@ To add a Transaction Item (Ecommerce)
 To add a Custom Dimension
 * `window.analytics.addCustomDimension('Key', 'Value', success, error)`
 
-To set a UserId:
+To set a UserId (not currently supported on Windows Phone 8):
 * `window.analytics.setUserId('my-user-id')`
 
 To enable verbose logging:

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
     <engine name="cordova" version=">=3.0.0" />
   </engines>
   <name>Google Universal Analytics Plugin</name>
-  <description>Simple tracking (screens/events) for Google Analytics SDK 3.14 (iOS) and SDK 4.0 (Android)</description>
+  <description>Simple tracking (screens/events) for Google Analytics SDK 3.14 (iOS), SDK 4.0 (Android), and WP8</description>
   <author>Daniel C. Wilson</author>
   <license>MIT License</license>
   <js-module src="www/analytics.js" name="UniversalAnalytics">
@@ -34,7 +34,6 @@
     <header-file src="ios/GAIEcommerceProduct.h" />
     <header-file src="ios/GAIEcommerceProductAction.h" />
     <header-file src="ios/GAIEcommercePromotion.h" />
-
 
     <framework src="SystemConfiguration.framework" />
     <framework src="CoreData.framework" />
@@ -70,5 +69,22 @@
         <service android:name="com.google.android.gms.analytics.CampaignTrackingService" />
     </config-file>
     <source-file src="android/UniversalAnalyticsPlugin.java" target-dir="src/com/danielcwilson/plugins/analytics" />
+  </platform>
+
+  <platform name="wp8">
+    <config-file target="config.xml" parent="/*">
+      <feature name="UniversalAnalytics">
+        <param name="wp-package" value="UniversalAnalyticsPlugin" />
+      </feature>
+    </config-file>
+
+    <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+        <Capability Name="ID_CAP_NETWORKING" />
+    </config-file>
+
+    <source-file src="wp8/UniversalAnalytics.cs" />
+    <source-file src="wp8/PhoneHelpers.cs" />
+    <source-file src="wp8/PhoneNameResolver.cs" />
+    <source-file src="wp8/PlatformInfoProvider.WP.cs" />
   </platform>
 </plugin>

--- a/wp8/PhoneHelpers.cs
+++ b/wp8/PhoneHelpers.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Xml;
+
+namespace UniversalAnalyticsPlugin
+{
+    internal static class Helpers
+    {
+        public static string GetAppAttribute(string attributeName)
+        {
+            try
+            {
+                XmlReaderSettings xmlReaderSettings = new XmlReaderSettings();
+                xmlReaderSettings.XmlResolver = new XmlXapResolver();
+                using (XmlReader xmlReader = XmlReader.Create("WMAppManifest.xml", xmlReaderSettings))
+                {
+                    xmlReader.ReadToDescendant("App");
+                    if (!xmlReader.IsStartElement())
+                    {
+                        throw new FormatException("WMAppManifest.xml is missing");
+                    }
+                    return xmlReader.GetAttribute(attributeName);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/wp8/PhoneNameResolver.cs
+++ b/wp8/PhoneNameResolver.cs
@@ -1,0 +1,488 @@
+﻿﻿/*
+ * Copyright (c) 2013 by Alan Mendelevich
+ * 
+ * Licensed under MIT license.
+ * 
+ * See license.txt for details.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace UniversalAnalyticsPlugin
+{
+    internal static class PhoneNameResolver
+    {
+        public static CanonicalPhoneName Resolve(string manufacturer, string model)
+        {
+            var manufacturerNormalized = manufacturer.Trim().ToUpper();
+
+            switch (manufacturerNormalized)
+            {
+                case "NOKIA":
+                    return ResolveNokia(manufacturer, model);
+                case "HTC":
+                    return ResolveHtc(manufacturer, model);
+                case "SAMSUNG":
+                    return ResolveSamsung(manufacturer, model);
+                case "LG":
+                    return ResolveLg(manufacturer, model);
+                case "HUAWEI":
+                    return ResolveHuawei(manufacturer, model);
+                default:
+                    return new CanonicalPhoneName()
+                    {
+                        ReportedManufacturer = manufacturer,
+                        ReportedModel = model,
+                        CanonicalManufacturer = manufacturer,
+                        CanonicalModel = model,
+                        IsResolved = false
+                    };
+
+            }
+        }
+
+
+
+        private static CanonicalPhoneName ResolveHuawei(string manufacturer, string model)
+        {
+            var modelNormalized = model.Trim().ToUpper();
+
+            var result = new CanonicalPhoneName()
+            {
+                ReportedManufacturer = manufacturer,
+                ReportedModel = model,
+                CanonicalManufacturer = "HUAWEI",
+                CanonicalModel = model,
+                IsResolved = false
+            };
+
+
+            var lookupValue = modelNormalized;
+
+            if (lookupValue.StartsWith("HUAWEI H883G"))
+            {
+                lookupValue = "HUAWEI H883G";
+            }
+
+            if (lookupValue.StartsWith("HUAWEI W1"))
+            {
+                lookupValue = "HUAWEI W1";
+            }
+
+            if (modelNormalized.StartsWith("HUAWEI W2"))
+            {
+                lookupValue = "HUAWEI W2";
+            }
+
+            if (huaweiLookupTable.ContainsKey(lookupValue))
+            {
+                var modelMetadata = huaweiLookupTable[lookupValue];
+                result.CanonicalModel = modelMetadata.CanonicalModel;
+                result.Comments = modelMetadata.Comments;
+                result.IsResolved = true;
+            }
+
+            return result;
+        }
+
+
+
+        private static CanonicalPhoneName ResolveLg(string manufacturer, string model)
+        {
+            var modelNormalized = model.Trim().ToUpper();
+
+            var result = new CanonicalPhoneName()
+            {
+                ReportedManufacturer = manufacturer,
+                ReportedModel = model,
+                CanonicalManufacturer = "LG",
+                CanonicalModel = model,
+                IsResolved = false
+            };
+
+
+            var lookupValue = modelNormalized;
+
+            if (lookupValue.StartsWith("LG-C900"))
+            {
+                lookupValue = "LG-C900";
+            }
+
+            if (lookupValue.StartsWith("LG-E900"))
+            {
+                lookupValue = "LG-E900";
+            }
+
+            if (lgLookupTable.ContainsKey(lookupValue))
+            {
+                var modelMetadata = lgLookupTable[lookupValue];
+                result.CanonicalModel = modelMetadata.CanonicalModel;
+                result.Comments = modelMetadata.Comments;
+                result.IsResolved = true;
+            }
+
+            return result;
+        }
+
+        private static CanonicalPhoneName ResolveSamsung(string manufacturer, string model)
+        {
+            var modelNormalized = model.Trim().ToUpper();
+
+            var result = new CanonicalPhoneName()
+            {
+                ReportedManufacturer = manufacturer,
+                ReportedModel = model,
+                CanonicalManufacturer = "SAMSUNG",
+                CanonicalModel = model,
+                IsResolved = false
+            };
+
+
+            var lookupValue = modelNormalized;
+
+            if (lookupValue.StartsWith("GT-S7530"))
+            {
+                lookupValue = "GT-S7530";
+            }
+
+            if (lookupValue.StartsWith("SGH-I917"))
+            {
+                lookupValue = "SGH-I917";
+            }
+
+            if (samsungLookupTable.ContainsKey(lookupValue))
+            {
+                var modelMetadata = samsungLookupTable[lookupValue];
+                result.CanonicalModel = modelMetadata.CanonicalModel;
+                result.Comments = modelMetadata.Comments;
+                result.IsResolved = true;
+            }
+
+            return result;
+        }
+
+        private static CanonicalPhoneName ResolveHtc(string manufacturer, string model)
+        {
+            var modelNormalized = model.Trim().ToUpper();
+
+            var result = new CanonicalPhoneName()
+            {
+                ReportedManufacturer = manufacturer,
+                ReportedModel = model,
+                CanonicalManufacturer = "HTC",
+                CanonicalModel = model,
+                IsResolved = false
+            };
+
+
+            var lookupValue = modelNormalized;
+
+            if (lookupValue.StartsWith("A620"))
+            {
+                lookupValue = "A620";
+            }
+
+            if (lookupValue.StartsWith("C625"))
+            {
+                lookupValue = "C625";
+            }
+
+            if (lookupValue.StartsWith("C620"))
+            {
+                lookupValue = "C625";
+            }
+
+            if (htcLookupTable.ContainsKey(lookupValue))
+            {
+                var modelMetadata = htcLookupTable[lookupValue];
+                result.CanonicalModel = modelMetadata.CanonicalModel;
+                result.Comments = modelMetadata.Comments;
+                result.IsResolved = true;
+            }
+
+            return result;
+        }
+
+        private static CanonicalPhoneName ResolveNokia(string manufacturer, string model)
+        {
+            var modelNormalized = model.Trim().ToUpper();
+
+            var result = new CanonicalPhoneName()
+            {
+                ReportedManufacturer = manufacturer,
+                ReportedModel = model,
+                CanonicalManufacturer = "NOKIA",
+                CanonicalModel = model,
+                IsResolved = false
+            };
+
+            var lookupValue = modelNormalized;
+            if (modelNormalized.StartsWith("RM-"))
+            {
+                lookupValue = modelNormalized.Substring(0, 6);
+            }
+
+            if (nokiaLookupTable.ContainsKey(lookupValue))
+            {
+                var modelMetadata = nokiaLookupTable[lookupValue];
+                result.CanonicalModel = modelMetadata.CanonicalModel;
+                result.Comments = modelMetadata.Comments;
+                result.IsResolved = true;
+            }
+
+            return result;
+        }
+
+
+        private static Dictionary<string, CanonicalPhoneName> huaweiLookupTable = new Dictionary<string, CanonicalPhoneName>()
+        {
+            // Huawei W1
+            { "HUAWEI H883G", new CanonicalPhoneName() { CanonicalModel = "Ascend W1" } },
+            { "HUAWEI W1", new CanonicalPhoneName() { CanonicalModel = "Ascend W1" } },
+            
+            // Huawei Ascend W2
+            { "HUAWEI W2", new CanonicalPhoneName() { CanonicalModel = "Ascend W2" } },
+        };
+
+
+        private static Dictionary<string, CanonicalPhoneName> lgLookupTable = new Dictionary<string, CanonicalPhoneName>()
+        {
+            // Optimus 7Q/Quantum
+            { "LG-C900", new CanonicalPhoneName() { CanonicalModel = "Optimus 7Q/Quantum" } },
+
+            // Optimus 7
+            { "LG-E900", new CanonicalPhoneName() { CanonicalModel = "Optimus 7" } },
+
+            // Jil Sander
+            { "LG-E906", new CanonicalPhoneName() { CanonicalModel = "Jil Sander" } },
+        };
+
+        private static Dictionary<string, CanonicalPhoneName> samsungLookupTable = new Dictionary<string, CanonicalPhoneName>()
+        {
+            // OMNIA W
+            { "GT-I8350", new CanonicalPhoneName() { CanonicalModel = "Omnia W" } },
+            { "GT-I8350T", new CanonicalPhoneName() { CanonicalModel = "Omnia W" } },
+            { "OMNIA W", new CanonicalPhoneName() { CanonicalModel = "Omnia W" } },
+
+            // OMNIA 7
+            { "GT-I8700", new CanonicalPhoneName() { CanonicalModel = "Omnia 7" } },
+            { "OMNIA7", new CanonicalPhoneName() { CanonicalModel = "Omnia 7" } },
+
+            // OMNIA M
+            { "GT-S7530", new CanonicalPhoneName() { CanonicalModel = "Omnia 7" } },
+
+            // Focus
+            { "I917", new CanonicalPhoneName() { CanonicalModel = "Focus" } },
+            { "SGH-I917", new CanonicalPhoneName() { CanonicalModel = "Focus" } },
+
+            // Focus 2
+            { "SGH-I667", new CanonicalPhoneName() { CanonicalModel = "Focus 2" } },
+
+            // Focus Flash
+            { "SGH-I677", new CanonicalPhoneName() { CanonicalModel = "Focus Flash" } },
+
+            // Focus S
+            { "HADEN", new CanonicalPhoneName() { CanonicalModel = "Focus S" } },
+            { "SGH-I937", new CanonicalPhoneName() { CanonicalModel = "Focus S" } },
+
+            // ATIV S
+            { "GT-I8750", new CanonicalPhoneName() { CanonicalModel = "ATIV S" } },
+            { "SGH-T899M", new CanonicalPhoneName() { CanonicalModel = "ATIV S" } },
+
+            // ATIV Odyssey
+            { "SCH-I930", new CanonicalPhoneName() { CanonicalModel = "ATIV Odyssey" } },
+            { "SCH-R860U", new CanonicalPhoneName() { CanonicalModel = "ATIV Odyssey", Comments="US Cellular" } },
+
+            // ATIV S Neo
+            { "SPH-I800", new CanonicalPhoneName() { CanonicalModel = "ATIV S Neo", Comments="Sprint" } },
+            { "SGH-I187", new CanonicalPhoneName() { CanonicalModel = "ATIV S Neo", Comments="AT&T" } },
+            { "GT-I8675", new CanonicalPhoneName() { CanonicalModel = "ATIV S Neo" } },
+        };
+
+        private static Dictionary<string, CanonicalPhoneName> htcLookupTable = new Dictionary<string, CanonicalPhoneName>()
+        {
+            // Surround
+            { "7 MONDRIAN T8788", new CanonicalPhoneName() { CanonicalModel = "Surround" } },
+            { "T8788", new CanonicalPhoneName() { CanonicalModel = "Surround" } },
+            { "SURROUND", new CanonicalPhoneName() { CanonicalModel = "Surround" } },
+            { "SURROUND T8788", new CanonicalPhoneName() { CanonicalModel = "Surround" } },
+
+            // Mozart
+            { "7 MOZART", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "7 MOZART T8698", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "HTC MOZART", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "MERSAD 7 MOZART T8698", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "MOZART", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "MOZART T8698", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "PD67100", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+            { "T8697", new CanonicalPhoneName() { CanonicalModel = "Mozart" } },
+
+            // Pro
+            { "7 PRO T7576", new CanonicalPhoneName() { CanonicalModel = "7 Pro" } },
+            { "MWP6885", new CanonicalPhoneName() { CanonicalModel = "7 Pro" } },
+            { "USCCHTC-PC93100", new CanonicalPhoneName() { CanonicalModel = "7 Pro" } },
+
+            // Arrive
+            { "PC93100", new CanonicalPhoneName() { CanonicalModel = "Arrive", Comments = "Sprint" } },
+            { "T7575", new CanonicalPhoneName() { CanonicalModel = "Arrive", Comments = "Sprint" } },
+
+            // HD2
+            { "HD2", new CanonicalPhoneName() { CanonicalModel = "HD2" } },
+            { "HD2 LEO", new CanonicalPhoneName() { CanonicalModel = "HD2" } },
+            { "LEO", new CanonicalPhoneName() { CanonicalModel = "HD2" } },
+
+            // HD7
+            { "7 SCHUBERT T9292", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "GOLD", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "HD7", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "HD7 T9292", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "MONDRIAN", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "SCHUBERT", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "Schubert T9292", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+            { "T9296", new CanonicalPhoneName() { CanonicalModel = "HD7", Comments = "Telstra, AU" } },
+            { "TOUCH-IT HD7", new CanonicalPhoneName() { CanonicalModel = "HD7" } },
+
+            // HD7S
+            { "T9295", new CanonicalPhoneName() { CanonicalModel = "HD7S" } },
+
+            // Trophy
+            { "7 TROPHY", new CanonicalPhoneName() { CanonicalModel = "Trophy" } },
+            { "7 TROPHY T8686", new CanonicalPhoneName() { CanonicalModel = "Trophy" } },
+            { "PC40100", new CanonicalPhoneName() { CanonicalModel = "Trophy", Comments = "Verizon" } },
+            { "SPARK", new CanonicalPhoneName() { CanonicalModel = "Trophy" } },
+            { "TOUCH-IT TROPHY", new CanonicalPhoneName() { CanonicalModel = "Trophy" } },
+            { "MWP6985", new CanonicalPhoneName() { CanonicalModel = "Trophy" } },
+
+            // 8S
+            { "A620", new CanonicalPhoneName() { CanonicalModel = "8S" } },
+            { "WINDOWS PHONE 8S BY HTC", new CanonicalPhoneName() { CanonicalModel = "8S" } },
+
+            // 8X
+            { "C620", new CanonicalPhoneName() { CanonicalModel = "8X" } },
+            { "C625", new CanonicalPhoneName() { CanonicalModel = "8X" } },
+            { "HTC6990LVW", new CanonicalPhoneName() { CanonicalModel = "8X", Comments="Verizon" } },
+            { "PM23300", new CanonicalPhoneName() { CanonicalModel = "8X", Comments="AT&T" } },
+            { "WINDOWS PHONE 8X BY HTC", new CanonicalPhoneName() { CanonicalModel = "8X" } },
+
+            // 8XT
+            { "HTCPO881 SPRINT", new CanonicalPhoneName() { CanonicalModel = "8XT", Comments="Sprint" } },
+
+            // Titan
+            { "ETERNITY", new CanonicalPhoneName() { CanonicalModel = "Titan", Comments = "China" } },
+            { "PI39100", new CanonicalPhoneName() { CanonicalModel = "Titan", Comments = "AT&T" } },
+            { "TITAN X310E", new CanonicalPhoneName() { CanonicalModel = "Titan" } },
+            { "ULTIMATE", new CanonicalPhoneName() { CanonicalModel = "Titan" } },
+            { "X310E", new CanonicalPhoneName() { CanonicalModel = "Titan" } },
+            { "X310E TITAN", new CanonicalPhoneName() { CanonicalModel = "Titan" } },
+            
+            // Titan II
+            { "PI86100", new CanonicalPhoneName() { CanonicalModel = "Titan II", Comments = "AT&T" } },
+            { "RADIANT", new CanonicalPhoneName() { CanonicalModel = "Titan II" } },
+
+            // Radar
+            { "RADAR", new CanonicalPhoneName() { CanonicalModel = "Radar" } },
+            { "RADAR 4G", new CanonicalPhoneName() { CanonicalModel = "Radar", Comments = "T-Mobile USA" } },
+            { "RADAR C110E", new CanonicalPhoneName() { CanonicalModel = "Radar" } },
+            
+        };
+
+        private static Dictionary<string, CanonicalPhoneName> nokiaLookupTable = new Dictionary<string, CanonicalPhoneName>()
+        {
+            // Lumia 505
+            { "LUMIA 505", new CanonicalPhoneName() { CanonicalModel = "Lumia 505" } },
+            // Lumia 510
+            { "LUMIA 510", new CanonicalPhoneName() { CanonicalModel = "Lumia 510" } },
+            { "NOKIA 510", new CanonicalPhoneName() { CanonicalModel = "Lumia 510" } },
+            // Lumia 610
+            { "LUMIA 610", new CanonicalPhoneName() { CanonicalModel = "Lumia 610" } },
+            { "LUMIA 610 NFC", new CanonicalPhoneName() { CanonicalModel = "Lumia 610", Comments = "NFC" } },
+            { "NOKIA 610", new CanonicalPhoneName() { CanonicalModel = "Lumia 610" } },
+            { "NOKIA 610C", new CanonicalPhoneName() { CanonicalModel = "Lumia 610" } },
+            // Lumia 620
+            { "LUMIA 620", new CanonicalPhoneName() { CanonicalModel = "Lumia 620" } },
+            { "RM-846", new CanonicalPhoneName() { CanonicalModel = "Lumia 620" } },
+            // Lumia 710
+            { "LUMIA 710", new CanonicalPhoneName() { CanonicalModel = "Lumia 710" } },
+            { "NOKIA 710", new CanonicalPhoneName() { CanonicalModel = "Lumia 710" } },
+            // Lumia 800
+            { "LUMIA 800", new CanonicalPhoneName() { CanonicalModel = "Lumia 800" } },
+            { "LUMIA 800C", new CanonicalPhoneName() { CanonicalModel = "Lumia 800" } },
+            { "NOKIA 800", new CanonicalPhoneName() { CanonicalModel = "Lumia 800" } },
+            { "NOKIA 800C", new CanonicalPhoneName() { CanonicalModel = "Lumia 800", Comments = "China" } },
+            // Lumia 810
+            { "RM-878", new CanonicalPhoneName() { CanonicalModel = "Lumia 810" } },
+            // Lumia 820
+            { "RM-824", new CanonicalPhoneName() { CanonicalModel = "Lumia 820" } },
+            { "RM-825", new CanonicalPhoneName() { CanonicalModel = "Lumia 820" } },
+            { "RM-826", new CanonicalPhoneName() { CanonicalModel = "Lumia 820" } },
+            // Lumia 822
+            { "RM-845", new CanonicalPhoneName() { CanonicalModel = "Lumia 822", Comments = "Verizon" } },
+            // Lumia 900
+            { "LUMIA 900", new CanonicalPhoneName() { CanonicalModel = "Lumia 900" } },
+            { "NOKIA 900", new CanonicalPhoneName() { CanonicalModel = "Lumia 900" } },
+            // Lumia 920
+            { "RM-820", new CanonicalPhoneName() { CanonicalModel = "Lumia 920" } },
+            { "RM-821", new CanonicalPhoneName() { CanonicalModel = "Lumia 920" } },
+            { "RM-822", new CanonicalPhoneName() { CanonicalModel = "Lumia 920" } },
+            { "RM-867", new CanonicalPhoneName() { CanonicalModel = "Lumia 920", Comments = "920T" } },
+            { "NOKIA 920", new CanonicalPhoneName() { CanonicalModel = "Lumia 920" } },
+            { "LUMIA 920", new CanonicalPhoneName() { CanonicalModel = "Lumia 920" } },
+            // Lumia 520
+            { "RM-914", new CanonicalPhoneName() { CanonicalModel = "Lumia 520" } },
+            { "RM-915", new CanonicalPhoneName() { CanonicalModel = "Lumia 520" } },
+            { "RM-913", new CanonicalPhoneName() { CanonicalModel = "Lumia 520", Comments="520T" } },
+            // Lumia 521?
+            { "RM-917", new CanonicalPhoneName() { CanonicalModel = "Lumia 521", Comments="T-Mobile 520" } },
+            // Lumia 720
+            { "RM-885", new CanonicalPhoneName() { CanonicalModel = "Lumia 720" } },
+            { "RM-887", new CanonicalPhoneName() { CanonicalModel = "Lumia 720", Comments="China 720T" } },
+            // Lumia 928
+            { "RM-860", new CanonicalPhoneName() { CanonicalModel = "Lumia 928" } },
+            // Lumia 925
+            { "RM-892", new CanonicalPhoneName() { CanonicalModel = "Lumia 925" } },
+            { "RM-893", new CanonicalPhoneName() { CanonicalModel = "Lumia 925" } },
+            { "RM-910", new CanonicalPhoneName() { CanonicalModel = "Lumia 925" } },
+            { "RM-955", new CanonicalPhoneName() { CanonicalModel = "Lumia 925", Comments="China 925T" } },
+            // Lumia 1020
+            { "RM-875", new CanonicalPhoneName() { CanonicalModel = "Lumia 1020" } },
+            { "RM-876", new CanonicalPhoneName() { CanonicalModel = "Lumia 1020" } },
+            { "RM-877", new CanonicalPhoneName() { CanonicalModel = "Lumia 1020" } },
+            // Lumia 625
+            { "RM-941", new CanonicalPhoneName() { CanonicalModel = "Lumia 625" } },
+            { "RM-942", new CanonicalPhoneName() { CanonicalModel = "Lumia 625" } },
+            { "RM-943", new CanonicalPhoneName() { CanonicalModel = "Lumia 625" } },
+            // Lumia 1520
+            { "RM-937", new CanonicalPhoneName() { CanonicalModel = "Lumia 1520" } },
+            { "RM-938", new CanonicalPhoneName() { CanonicalModel = "Lumia 1520", Comments="AT&T" } },
+            { "RM-939", new CanonicalPhoneName() { CanonicalModel = "Lumia 1520" } },
+            { "RM-940", new CanonicalPhoneName() { CanonicalModel = "Lumia 1520", Comments="AT&T" } },
+            // Lumia 525
+            { "RM-998", new CanonicalPhoneName() { CanonicalModel = "Lumia 525" } },
+            // Lumia 1320
+            { "RM-994", new CanonicalPhoneName() { CanonicalModel = "Lumia 1320" } },
+            { "RM-995", new CanonicalPhoneName() { CanonicalModel = "Lumia 1320" } },
+            { "RM-996", new CanonicalPhoneName() { CanonicalModel = "Lumia 1320" } },
+            // Lumia Icon
+            { "RM-927", new CanonicalPhoneName() { CanonicalModel = "Lumia Icon", Comments="Verizon" } },
+        };
+    }
+
+    public class CanonicalPhoneName
+    {
+        public string ReportedManufacturer { get; set; }
+        public string ReportedModel { get; set; }
+        public string CanonicalManufacturer { get; set; }
+        public string CanonicalModel { get; set; }
+        public string Comments { get; set; }
+        public bool IsResolved { get; set; }
+
+        public string FullCanonicalName
+        {
+            get { return CanonicalManufacturer + " " + CanonicalModel; }
+        }
+    }
+
+}

--- a/wp8/PhoneNameResolver.cs
+++ b/wp8/PhoneNameResolver.cs
@@ -1,4 +1,4 @@
-﻿﻿/*
+﻿/*
  * Copyright (c) 2013 by Alan Mendelevich
  * 
  * Licensed under MIT license.
@@ -10,10 +10,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace UniversalAnalyticsPlugin
 {
-    internal static class PhoneNameResolver
+    public static class PhoneNameResolver
     {
         public static CanonicalPhoneName Resolve(string manufacturer, string model)
         {
@@ -22,6 +23,7 @@ namespace UniversalAnalyticsPlugin
             switch (manufacturerNormalized)
             {
                 case "NOKIA":
+                case "MICROSOFT":
                     return ResolveNokia(manufacturer, model);
                 case "HTC":
                     return ResolveHtc(manufacturer, model);
@@ -40,11 +42,8 @@ namespace UniversalAnalyticsPlugin
                         CanonicalModel = model,
                         IsResolved = false
                     };
-
             }
         }
-
-
 
         private static CanonicalPhoneName ResolveHuawei(string manufacturer, string model)
         {
@@ -58,7 +57,6 @@ namespace UniversalAnalyticsPlugin
                 CanonicalModel = model,
                 IsResolved = false
             };
-
 
             var lookupValue = modelNormalized;
 
@@ -88,8 +86,6 @@ namespace UniversalAnalyticsPlugin
             return result;
         }
 
-
-
         private static CanonicalPhoneName ResolveLg(string manufacturer, string model)
         {
             var modelNormalized = model.Trim().ToUpper();
@@ -102,7 +98,6 @@ namespace UniversalAnalyticsPlugin
                 CanonicalModel = model,
                 IsResolved = false
             };
-
 
             var lookupValue = modelNormalized;
 
@@ -140,7 +135,6 @@ namespace UniversalAnalyticsPlugin
                 IsResolved = false
             };
 
-
             var lookupValue = modelNormalized;
 
             if (lookupValue.StartsWith("GT-S7530"))
@@ -177,7 +171,6 @@ namespace UniversalAnalyticsPlugin
                 IsResolved = false
             };
 
-
             var lookupValue = modelNormalized;
 
             if (lookupValue.StartsWith("A620"))
@@ -192,7 +185,7 @@ namespace UniversalAnalyticsPlugin
 
             if (lookupValue.StartsWith("C620"))
             {
-                lookupValue = "C625";
+                lookupValue = "C620";
             }
 
             if (htcLookupTable.ContainsKey(lookupValue))
@@ -222,12 +215,18 @@ namespace UniversalAnalyticsPlugin
             var lookupValue = modelNormalized;
             if (modelNormalized.StartsWith("RM-"))
             {
-                lookupValue = modelNormalized.Substring(0, 6);
+                var rms = Regex.Match(modelNormalized, "(RM-)([0-9]+)");
+                lookupValue = rms.Value;
             }
 
             if (nokiaLookupTable.ContainsKey(lookupValue))
             {
                 var modelMetadata = nokiaLookupTable[lookupValue];
+
+                if (!string.IsNullOrEmpty(modelMetadata.CanonicalManufacturer))
+                {
+                    result.CanonicalManufacturer = modelMetadata.CanonicalManufacturer;
+                }
                 result.CanonicalModel = modelMetadata.CanonicalModel;
                 result.Comments = modelMetadata.Comments;
                 result.IsResolved = true;
@@ -246,7 +245,6 @@ namespace UniversalAnalyticsPlugin
             // Huawei Ascend W2
             { "HUAWEI W2", new CanonicalPhoneName() { CanonicalModel = "Ascend W2" } },
         };
-
 
         private static Dictionary<string, CanonicalPhoneName> lgLookupTable = new Dictionary<string, CanonicalPhoneName>()
         {
@@ -300,6 +298,9 @@ namespace UniversalAnalyticsPlugin
             { "SPH-I800", new CanonicalPhoneName() { CanonicalModel = "ATIV S Neo", Comments="Sprint" } },
             { "SGH-I187", new CanonicalPhoneName() { CanonicalModel = "ATIV S Neo", Comments="AT&T" } },
             { "GT-I8675", new CanonicalPhoneName() { CanonicalModel = "ATIV S Neo" } },
+
+            // ATIV SE
+            { "SM-W750V", new CanonicalPhoneName() { CanonicalModel = "ATIV SE", Comments="Verizon" } },
         };
 
         private static Dictionary<string, CanonicalPhoneName> htcLookupTable = new Dictionary<string, CanonicalPhoneName>()
@@ -368,7 +369,9 @@ namespace UniversalAnalyticsPlugin
             { "WINDOWS PHONE 8X BY HTC", new CanonicalPhoneName() { CanonicalModel = "8X" } },
 
             // 8XT
+            { "HTCPO881", new CanonicalPhoneName() { CanonicalModel = "8XT", Comments="Sprint" } },
             { "HTCPO881 SPRINT", new CanonicalPhoneName() { CanonicalModel = "8XT", Comments="Sprint" } },
+            { "HTCPO881 HTC", new CanonicalPhoneName() { CanonicalModel = "8XT", Comments="Sprint" } },
 
             // Titan
             { "ETERNITY", new CanonicalPhoneName() { CanonicalModel = "Titan", Comments = "China" } },
@@ -387,6 +390,10 @@ namespace UniversalAnalyticsPlugin
             { "RADAR 4G", new CanonicalPhoneName() { CanonicalModel = "Radar", Comments = "T-Mobile USA" } },
             { "RADAR C110E", new CanonicalPhoneName() { CanonicalModel = "Radar" } },
             
+            // One M8
+            { "HTC6995LVW", new CanonicalPhoneName() { CanonicalModel = "One (M8)", Comments="Verizon" } },
+            { "0P6B180", new CanonicalPhoneName() { CanonicalModel = "One (M8)", Comments="AT&T" } },
+            { "0P6B140", new CanonicalPhoneName() { CanonicalModel = "One (M8)", Comments="Dual SIM?" } },
         };
 
         private static Dictionary<string, CanonicalPhoneName> nokiaLookupTable = new Dictionary<string, CanonicalPhoneName>()
@@ -467,6 +474,56 @@ namespace UniversalAnalyticsPlugin
             { "RM-996", new CanonicalPhoneName() { CanonicalModel = "Lumia 1320" } },
             // Lumia Icon
             { "RM-927", new CanonicalPhoneName() { CanonicalModel = "Lumia Icon", Comments="Verizon" } },
+            // Lumia 630
+            { "RM-976", new CanonicalPhoneName() { CanonicalModel = "Lumia 630" } },
+            { "RM-977", new CanonicalPhoneName() { CanonicalModel = "Lumia 630" } },
+            { "RM-978", new CanonicalPhoneName() { CanonicalModel = "Lumia 630" } },
+            { "RM-979", new CanonicalPhoneName() { CanonicalModel = "Lumia 630" } },
+            // Lumia 635
+            { "RM-974", new CanonicalPhoneName() { CanonicalModel = "Lumia 635" } },
+            { "RM-975", new CanonicalPhoneName() { CanonicalModel = "Lumia 635" } },
+            { "RM-1078", new CanonicalPhoneName() { CanonicalModel = "Lumia 635", Comments="Sprint" } },
+            // Lumia 526
+            { "RM-997", new CanonicalPhoneName() { CanonicalModel = "Lumia 526", Comments="China Mobile" } },
+            // Lumia 930
+            { "RM-1045", new CanonicalPhoneName() { CanonicalModel = "Lumia 930" } },
+            { "RM-1087", new CanonicalPhoneName() { CanonicalModel = "Lumia 930" } },
+            // Lumia 636
+            { "RM-1027", new CanonicalPhoneName() { CanonicalModel = "Lumia 636", Comments="China" } },
+            // Lumia 638
+            { "RM-1010", new CanonicalPhoneName() { CanonicalModel = "Lumia 638", Comments="China" } },
+            // Lumia 530
+            { "RM-1017", new CanonicalPhoneName() { CanonicalModel = "Lumia 530", Comments="Single SIM" } },
+            { "RM-1018", new CanonicalPhoneName() { CanonicalModel = "Lumia 530", Comments="Single SIM" } },
+            { "RM-1019", new CanonicalPhoneName() { CanonicalModel = "Lumia 530", Comments="Dual SIM" } },
+            { "RM-1020", new CanonicalPhoneName() { CanonicalModel = "Lumia 530", Comments="Dual SIM" } },
+            // Lumia 730
+            { "RM-1040", new CanonicalPhoneName() { CanonicalModel = "Lumia 730", Comments="Dual SIM" } },
+            // Lumia 735
+            { "RM-1038", new CanonicalPhoneName() { CanonicalModel = "Lumia 735" } },
+            { "RM-1039", new CanonicalPhoneName() { CanonicalModel = "Lumia 735" } },
+            { "RM-1041", new CanonicalPhoneName() { CanonicalModel = "Lumia 735", Comments="Verizon" } },
+            // Lumia 830
+            { "RM-983", new CanonicalPhoneName() { CanonicalModel = "Lumia 830" } },
+            { "RM-984", new CanonicalPhoneName() { CanonicalModel = "Lumia 830" } },
+            { "RM-985", new CanonicalPhoneName() { CanonicalModel = "Lumia 830" } },
+            { "RM-1049", new CanonicalPhoneName() { CanonicalModel = "Lumia 830" } },
+            // Lumia 535
+            { "RM-1089", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 535" } },
+            { "RM-1090", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 535" } },
+            { "RM-1091", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 535" } },
+            { "RM-1092", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 535" } },
+            // Lumia 435
+            { "RM-1068", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
+            { "RM-1069", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
+            { "RM-1070", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
+            { "RM-1071", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
+            // Lumia 532
+            { "RM-1031", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
+            { "RM-1032", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
+            { "RM-1034", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
+            // Lumia 640
+            { "RM-1075", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
         };
     }
 
@@ -484,5 +541,4 @@ namespace UniversalAnalyticsPlugin
             get { return CanonicalManufacturer + " " + CanonicalModel; }
         }
     }
-
 }

--- a/wp8/PhoneNameResolver.cs
+++ b/wp8/PhoneNameResolver.cs
@@ -24,6 +24,7 @@ namespace UniversalAnalyticsPlugin
             {
                 case "NOKIA":
                 case "MICROSOFT":
+                case "MICROSOFTMDG":
                     return ResolveNokia(manufacturer, model);
                 case "HTC":
                     return ResolveHtc(manufacturer, model);
@@ -256,6 +257,9 @@ namespace UniversalAnalyticsPlugin
 
             // Jil Sander
             { "LG-E906", new CanonicalPhoneName() { CanonicalModel = "Jil Sander" } },
+
+            // Lancet
+            { "LGVW820", new CanonicalPhoneName() { CanonicalModel = "Lancet" } },
         };
 
         private static Dictionary<string, CanonicalPhoneName> samsungLookupTable = new Dictionary<string, CanonicalPhoneName>()
@@ -518,12 +522,42 @@ namespace UniversalAnalyticsPlugin
             { "RM-1069", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
             { "RM-1070", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
             { "RM-1071", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
+            { "RM-1114", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 435", Comments="DS" } },
             // Lumia 532
             { "RM-1031", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
             { "RM-1032", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
             { "RM-1034", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
+            { "RM-1115", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 532", Comments="DS" } },
             // Lumia 640
+            { "RM-1072", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
+            { "RM-1073", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
+            { "RM-1074", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
             { "RM-1075", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
+            { "RM-1077", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
+            { "RM-1109", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
+            { "RM-1113", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640" } },
+            // Lumia 640XL
+            { "RM-1062", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            { "RM-1063", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            { "RM-1064", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            { "RM-1065", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            { "RM-1066", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            { "RM-1067", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            { "RM-1096", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 640 XL" } },
+            // Lumia 540
+            { "RM-1140", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 540" } },
+            { "RM-1141", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 540" } },
+            // Lumia 430
+            { "RM-1099", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 430", Comments="DS" } },
+            // Lumia 950
+            { "RM-1104", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 950", Comments="DS" } },
+            { "RM-1105", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 950", Comments="DS" } },
+            { "RM-1118", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 950", Comments="DS" } },
+            // Lumia 950 XL
+            { "RM-1085", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 950 XL" } },
+            { "RM-1116", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 950 XL", Comments="DS" } },
+            // Lumia 550
+            { "RM-1127", new CanonicalPhoneName() { CanonicalManufacturer="MICROSOFT", CanonicalModel = "Lumia 550" } },
         };
     }
 

--- a/wp8/PlatformInfoProvider.WP.cs
+++ b/wp8/PlatformInfoProvider.WP.cs
@@ -1,4 +1,6 @@
-﻿using GoogleAnalytics.Core;
+﻿// PlatformInfoProvider.WP.cs
+
+using GoogleAnalytics.Core;
 using System;
 using System.IO.IsolatedStorage;
 using System.Threading.Tasks;

--- a/wp8/PlatformInfoProvider.WP.cs
+++ b/wp8/PlatformInfoProvider.WP.cs
@@ -1,0 +1,101 @@
+﻿using GoogleAnalytics.Core;
+using System;
+using System.IO.IsolatedStorage;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace UniversalAnalyticsPlugin
+{
+    public sealed class PlatformInfoProvider : IPlatformInfoProvider
+    {
+        const string Key_AnonymousClientId = "GoogleAnaltyics.AnonymousClientId";
+        string anonymousClientId;
+        Dimensions _screenResolution = new Dimensions(0,0);
+
+#pragma warning disable 0067
+        public event EventHandler ViewPortResolutionChanged;
+
+        public event EventHandler ScreenResolutionChanged;
+#pragma warning restore 0067
+
+        public PlatformInfoProvider()
+        {
+            Deployment.Current.Dispatcher.BeginInvoke(() => {
+                double scale = (double)Application.Current.Host.Content.ScaleFactor / 100;
+                int h = (int)Math.Ceiling(Application.Current.Host.Content.ActualHeight * scale);
+                int w = (int)Math.Ceiling(Application.Current.Host.Content.ActualWidth * scale);               
+                _screenResolution = new Dimensions(h, w);
+            });
+        }
+
+        public string AnonymousClientId
+        {
+            get
+            {
+                if (anonymousClientId == null)
+                {
+                    var appSettings = IsolatedStorageSettings.ApplicationSettings;
+                    if (!appSettings.Contains(Key_AnonymousClientId))
+                    {
+                        anonymousClientId = Guid.NewGuid().ToString();
+                        appSettings.Add(Key_AnonymousClientId, anonymousClientId);
+                        appSettings.Save();
+                    }
+                    else
+                    {
+                        anonymousClientId = (string)appSettings[Key_AnonymousClientId];
+                    }
+                }
+                return anonymousClientId;
+            }
+            set { anonymousClientId = value; }
+        }
+
+        public Dimensions ScreenResolution
+        {
+            get
+            {
+                return _screenResolution;
+            }
+        }
+
+        public Dimensions ViewPortResolution
+        {
+            get { return ScreenResolution; }
+        }
+
+        public string UserLanguage
+        {
+            get { return System.Globalization.CultureInfo.CurrentUICulture.Name; }
+        }
+
+        public int? ScreenColorDepthBits
+        {
+            get { return null; }
+        }
+
+        public void OnTracking()
+        { }
+
+        public string GetUserAgent()
+        {
+            var sysInfo = UniversalAnalyticsPlugin.PhoneNameResolver.Resolve(Microsoft.Phone.Info.DeviceStatus.DeviceManufacturer, Microsoft.Phone.Info.DeviceStatus.DeviceName);
+            Version osVer = Environment.OSVersion.Version;
+            string uaMask;
+
+            if (osVer.Minor == 10)
+            {
+                // Windows Phone 8.1
+                uaMask = "Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv11.0; IEMobile/11.0; {1}; {2}) like Gecko";
+            }
+            else
+            {
+                // Windows Phone 8.0
+                uaMask = "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone OS {0}; Trident/6.0; IEMobile/10.0; ARM; Touch; {1}; {2})";
+            }
+
+            //var userAgentMask = "Mozilla/[version] ([system and browser information]) [platform] ([platform details]) [extensions]";
+            return string.Format(uaMask, Environment.OSVersion.Version, sysInfo.CanonicalManufacturer, sysInfo.CanonicalModel);       
+        }
+    }
+}

--- a/wp8/UniversalAnalytics.cs
+++ b/wp8/UniversalAnalytics.cs
@@ -202,6 +202,8 @@ namespace Cordova.Extension.Commands
 
             if (hasIndex && value != null)
             {
+                // Remove the key if it already exists
+                _customDimensions.Remove(index);
                 _customDimensions.Add(index, value);
                 DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Add Custom Dimension: " + index));
             }

--- a/wp8/UniversalAnalytics.cs
+++ b/wp8/UniversalAnalytics.cs
@@ -1,0 +1,250 @@
+// UniversalAnalytics.cs
+// Dan Polivy (dpolivy)
+
+using System;
+using GoogleAnalytics.Core;
+using WPCordovaClassLib.Cordova;
+using WPCordovaClassLib.Cordova.Commands;
+using WPCordovaClassLib.Cordova.JSON;
+using System.Collections.Generic;
+using System.Windows;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Phone.Shell;
+
+namespace Cordova.Extension.Commands
+{
+    /// <summary>
+    /// UniversalAnalytics plugin class containing methods called from JavaScript
+    /// </summary>
+    public class UniversalAnalytics : BaseCommand
+    {
+        private TrackerManager _trackerManager = new TrackerManager(new UniversalAnalyticsPlugin.PlatformInfoProvider());
+        private Tracker _tracker;
+        private bool _trackerStarted = false;
+        DateTime? _suspended;
+        private IDictionary<int, string> _customDimensions = new Dictionary<int, string>();
+
+        public UniversalAnalytics()
+	    {
+            this.AutoAppLifetimeTracking = false;
+            this.SessionTimeout = 30;
+	    }
+
+        /// <summary>
+        /// Session timeout length, in seconds.
+        /// </summary>
+        public int? SessionTimeout {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Determines whether events are automatically sent for app lifetime tracking.
+        /// </summary>
+        public bool AutoAppLifetimeTracking { get; set; }
+
+        public void startTrackerWithId(string options)
+        {
+            // If the tracker is already started, don't start it again
+            if (_trackerStarted)
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker is already started"));
+                return;
+            }
+
+            string[] args = JsonHelper.Deserialize<string[]>(options);
+
+            if (!_trackerStarted && args.Length > 0 && args[0].Length > 0)
+            {
+                _tracker = _trackerManager.GetTracker(args[0]);
+
+                // Set additional Tracker parameters here
+                _tracker.SetStartSession(true);
+                _tracker.IsUseSecure = true;
+                _tracker.AppName = UniversalAnalyticsPlugin.Helpers.GetAppAttribute("Title");
+                _tracker.AppVersion = UniversalAnalyticsPlugin.Helpers.GetAppAttribute("Version");
+
+                _trackerStarted = true;
+
+                Deployment.Current.Dispatcher.BeginInvoke(() =>
+                    {
+                        Application.Current.UnhandledException += Analytics_UnhandledException;
+                        TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+                    });
+
+                DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Tracker started"));
+            }
+            else
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker id is not valid"));
+            }
+        }
+
+        public override void OnResume(object sender, ActivatedEventArgs e)
+        {
+            if (_suspended.HasValue && SessionTimeout.HasValue)
+            {
+                var suspendedAgo = DateTime.UtcNow.Subtract(_suspended.Value);
+                if (suspendedAgo > TimeSpan.FromSeconds((double)SessionTimeout))
+                {
+                    _tracker.SetStartSession(true);
+                }
+            }
+
+            if (_trackerStarted && AutoAppLifetimeTracking)
+            {
+                _tracker.SendEvent("app", "resume", !e.IsApplicationInstancePreserved ? "tombstoned" : null, 0);
+            }
+        }
+
+        public override void OnPause(object sender, DeactivatedEventArgs e)
+        {
+            if (_trackerStarted && AutoAppLifetimeTracking)
+            {
+                _tracker.SendEvent("app", "suspend", e.Reason.ToString(), 0);
+            }
+
+            _suspended = DateTime.UtcNow;
+        }
+
+        private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            var ex = e.Exception.InnerException ?? e.Exception; // inner exception contains better info for unobserved tasks
+            _tracker.SendException(ex.ToString(), false);
+        }
+
+        private void Analytics_UnhandledException(object sender, ApplicationUnhandledExceptionEventArgs e)
+        {
+            _tracker.SendException(e.ExceptionObject.ToString(), true);
+
+            if (Debugger.IsAttached)
+            {
+                // An unhandled exception has occurred; break into the debugger
+                Debugger.Break();
+            }
+        }
+
+        public void setUserId(string options)
+        {
+            if (!_trackerStarted)
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker not started"));
+                return;
+            }
+
+            // TODO:
+            // Not Yet Implemented
+            DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Not yet implemented"));
+        }
+
+        public void debugMode(string options)
+        {          
+            _trackerManager.IsDebugEnabled = true;
+
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "debugMode enabled"));
+        }
+
+        public void trackView(string options)
+        {
+            if (!_trackerStarted)
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker not started"));
+                return;
+            }
+
+            string[] args = JsonHelper.Deserialize<string[]>(options);
+
+            if (args.Length > 0 && args[0].Length > 0)
+            {                
+                addCustomDimensionsToTracker(_tracker);
+                _tracker.SendView(args[0]);
+                DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Track Screen: " + args[0]));
+            }
+            else
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Expected one non-empty string argument"));
+            }
+        }
+
+        public void addCustomDimension(string options)
+        {
+            string[] args = JsonHelper.Deserialize<string[]>(options);
+
+            int index = 0;
+            bool hasIndex = false;
+            string value = null;
+
+            if (args.Length > 0) hasIndex = int.TryParse(args[0], out index);
+            if (args.Length > 1) value = args[1];
+
+            if (hasIndex && value != null)
+            {
+                _customDimensions.Add(index, value);
+            }
+            else 
+            {
+               DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Expected non-empty integer, string arguments"));
+            }
+        }
+
+        public void trackEvent(string options)
+        {
+            if (!_trackerStarted)
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker not started"));
+                return;
+            }
+
+            string[] args = JsonHelper.Deserialize<string[]>(options);
+
+            // Default values
+            string category = null, action = null, label = null;
+            long value = 0;
+
+            if (args.Length > 0) category = args[0];
+            if (args.Length > 1) action = args[1];
+            if (args.Length > 2) label = args[2];
+            if (args.Length > 3) long.TryParse(args[3], out value);
+
+            addCustomDimensionsToTracker(_tracker);
+            _tracker.SendEvent(category, action, label, value);
+
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Track Event: " + category));
+        }
+
+        public void addTransaction(string options)
+        {
+            if (!_trackerStarted)
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker not started"));
+                return;
+            }
+
+            // TODO:
+            // Not Yet Implemented
+            DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Not yet implemented"));
+        }
+
+        public void addTransactionItem(string options)
+        {
+            if (!_trackerStarted)
+            {
+                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Tracker not started"));
+                return;
+            }
+
+            // TODO:
+            // Not Yet Implemented
+            DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Not yet implemented"));
+        }
+
+        private void addCustomDimensionsToTracker(Tracker tracker)
+        {
+            foreach (KeyValuePair<int, string> dimension in _customDimensions)
+            {
+                tracker.SetCustomDimension(dimension.Key, dimension.Value);
+            }
+        }
+    }
+}

--- a/wp8/UniversalAnalytics.cs
+++ b/wp8/UniversalAnalytics.cs
@@ -1,5 +1,23 @@
-// UniversalAnalytics.cs
-// Dan Polivy (dpolivy)
+/*
+ * Copyright (c) 2016 Dan Polivy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 using System;
 using GoogleAnalytics.Core;
@@ -133,13 +151,17 @@ namespace Cordova.Extension.Commands
                 return;
             }
 
-            // TODO:
-            // Not Yet Implemented in the underlying Google Analytics SDK, so we can't add it here yet
-            DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Not yet implemented"));
+            string[] args = JsonHelper.Deserialize<string[]>(options);
+            string userId = null;
+
+            if (args.Length > 0) userId = args[0];
+
+            _tracker.UserId = userId;
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Set user id: " + args[0]));
         }
 
         public void debugMode(string options)
-        {          
+        {
             _trackerManager.IsDebugEnabled = true;
 
             DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "debugMode enabled"));
@@ -156,7 +178,7 @@ namespace Cordova.Extension.Commands
             string[] args = JsonHelper.Deserialize<string[]>(options);
 
             if (args.Length > 0 && args[0] != null && args[0].Length > 0)
-            {                
+            {
                 addCustomDimensionsToTracker(_tracker);
                 _tracker.SendView(args[0]);
                 DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Track Screen: " + args[0]));
@@ -183,7 +205,7 @@ namespace Cordova.Extension.Commands
                 _customDimensions.Add(index, value);
                 DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "Add Custom Dimension: " + index));
             }
-            else 
+            else
             {
                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, "Expected non-empty integer, string arguments"));
             }


### PR DESCRIPTION
This PR includes support for Windows Phone 8. All existing JS APIs are implemented, with the exception of setUserId, which is not currently available in the underlying Google Analytics SDK for WP.

The implementation is modeled after the iOS/Android versions. It uses the (unofficial) Google Analytics SDK to interact with the Google API. I haven't yet found a way to automate installation of a NuGet package as part of a plugin install, so in order to use this, you must manually add the NuGet package to your Visual Studio solution.

I've done some basic sanity testing on all of the API methods and they appear to be working as expected, however please let me know if you see any issues or would like any changes made to the code.