### PR TITLE
Added support for auto uncaught exception reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To set a UserId:
 To enable verbose logging:
 * `window.analytics.debugMode()`
 
+* `window.analytics.enableUncaughtExceptionReporting(Enable, success, error)` where Enable is boolean
+
 #Installing Without the CLI <a name="nocli"></a>
 Copy the files manually into your project and add the following to your config.xml files:
 ```xml

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To set a UserId:
 To enable verbose logging:
 * `window.analytics.debugMode()`
 
+To enable/disable automatic reporting of uncaught exceptions
 * `window.analytics.enableUncaughtExceptionReporting(Enable, success, error)` where Enable is boolean
 
 #Installing Without the CLI <a name="nocli"></a>

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -26,6 +26,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
     public static final String SET_USER_ID = "setUserId";
     public static final String DEBUG_MODE = "debugMode";
+    public static final String ENABLE_UNCAUGHT_EXCEPTION_REPORTING = "enableUncaughtExceptionReporting";
 
     public Boolean trackerStarted = false;
     public Boolean debugModeEnabled = false;
@@ -102,6 +103,9 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             this.setUserId(userId, callbackContext);
         } else if (DEBUG_MODE.equals(action)) {
             this.debugMode(callbackContext);
+        } else if (ENABLE_UNCAUGHT_EXCEPTION_REPORTING.equals(action)) {
+            Boolean enable = args.getBoolean(0);
+            this.enableUncaughtExceptionReporting(enable, callbackContext);
         }
         return false;
     }
@@ -290,5 +294,15 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
         tracker.set("&uid", userId);
         callbackContext.success("Set user id" + userId);
+    }
+    
+    private void enableUncaughtExceptionReporting(Boolean enable, CallbackContext callbackContext) {
+        if (! trackerStarted ) {
+            callbackContext.error("Tracker not started");
+            return;
+        }
+
+        tracker.enableExceptionReporting(enable);
+        callbackContext.success((enable ? "Enabled" : "Disabled") + " uncaught exception reporting");
     }
 }

--- a/ios/UniversalAnalyticsPlugin.h
+++ b/ios/UniversalAnalyticsPlugin.h
@@ -14,6 +14,7 @@
 - (void) startTrackerWithId: (CDVInvokedUrlCommand*)command;
 - (void) setUserId: (CDVInvokedUrlCommand*)command;
 - (void) debugMode: (CDVInvokedUrlCommand*)command;
+- (void) enableUncaughtExceptionReporting: (CDVInvokedUrlCommand*)command;
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command;
 - (void) trackEvent: (CDVInvokedUrlCommand*)command;
 - (void) trackTiming: (CDVInvokedUrlCommand*)command;

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -67,6 +67,23 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) enableUncaughtExceptionReporting: (CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* pluginResult = nil;
+    
+    if ( ! _trackerStarted) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Tracker not started"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
+    
+    bool enabled = [[command.arguments objectAtIndex:0] boolValue];
+    [[GAI sharedInstance] setTrackUncaughtExceptions:enabled];
+    
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -63,4 +63,9 @@ UniversalAnalyticsPlugin.prototype.addTransactionItem = function(transactionId, 
   cordova.exec(success, error, 'UniversalAnalytics', 'addTransactionItem', [transactionId, name ,sku, category, price, quantity, currencyCode]);
 };
 
+/* automatic uncaught exception tracking */
+UniversalAnalyticsPlugin.prototype.enableUncaughtExceptionReporting = function (enable, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'enableUncaughtExceptionReporting', [enable]);
+};
+
 module.exports = new UniversalAnalyticsPlugin();


### PR DESCRIPTION
Implementation of #101

Added support for automatic uncaught exception reporting, through the setting of Android's enableExceptionReporting(boolean) and iOS's setTrackUncaughtExceptions(boolean) methods through a common enableUncaughtExceptionReporting() plugin method

Updated from original pull request to include update to readme