### PR TITLE
Use framework instead of deprecated com.google.playservices

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
   </platform>
 
   <platform name="android">
-    <dependency id="com.google.playservices@19.0.0" />
+    <framework src="com.google.android.gms:play-services-plus:+" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="UniversalAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
   </platform>
 
   <platform name="android">
-    <framework src="com.google.android.gms:play-services-plus:+" />
+    <framework src="com.google.android.gms:play-services-analytics:+" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="UniversalAnalytics">


### PR DESCRIPTION
The use of deprecated com.google.playservices creates problem with some other plugins. The use of framework fixes them.