### PR TITLE
Module export should be exported only when module is defined

### DIFF
--- a/www/analytics.js
+++ b/www/analytics.js
@@ -63,4 +63,6 @@ UniversalAnalyticsPlugin.prototype.addTransactionItem = function(transactionId, 
   cordova.exec(success, error, 'UniversalAnalytics', 'addTransactionItem', [transactionId, name ,sku, category, price, quantity, currencyCode]);
 };
 
-module.exports = new UniversalAnalyticsPlugin();
+if (typeof module != 'undefined' && module.exports) {
+  module.exports = new UniversalAnalyticsPlugin();
+}


### PR DESCRIPTION
Many times people develop on browser like chrome. This change will not create a problem for them, even if the script is included. 