### PR TITLE
adds setAppVersion functionality (Android/iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ To add a Transaction Item (Ecommerce)
 
 To add a Custom Dimension
 * `window.analytics.addCustomDimension('Key', 'Value', success, error)`
-* Key should be integer index of the dimension i.e. send `1` instead of `dimension1` for the first custom dimension you are tracking. 
+* Key should be integer index of the dimension i.e. send `1` instead of `dimension1` for the first custom dimension you are tracking.
 * e.g. `window.analytics.addCustomDimension(1, 'Value', success, error)`
 
 To set a UserId:
 * `window.analytics.setUserId('my-user-id')`
+
+To set a specific app version:
+* `window.analytics.setAppVersion('1.33.7')`
 
 To enable verbose logging:
 * `window.analytics.debugMode()`

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -28,6 +28,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
     public static final String ADD_TRANSACTION_ITEM = "addTransactionItem";
 
     public static final String SET_USER_ID = "setUserId";
+    public static final String SET_APP_VERSION = "setAppVersion";
     public static final String DEBUG_MODE = "debugMode";
     public static final String ENABLE_UNCAUGHT_EXCEPTION_REPORTING = "enableUncaughtExceptionReporting";
 
@@ -113,6 +114,9 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         } else if (SET_USER_ID.equals(action)) {
             String userId = args.getString(0);
             this.setUserId(userId, callbackContext);
+        } else if (SET_APP_VERSION.equals(action)) {
+            String version = args.getString(0);
+            this.setAppVersion(version, callbackContext);
         } else if (DEBUG_MODE.equals(action)) {
             this.debugMode(callbackContext);
         } else if (ENABLE_UNCAUGHT_EXCEPTION_REPORTING.equals(action)) {
@@ -138,12 +142,12 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             callbackContext.error("Expected positive integer argument for key.");
             return;
         }
-    	
+
         if (null == value || value.length() == 0) {
             callbackContext.error("Expected non-empty string argument for value.");
             return;
         }
-    		
+
         customDimensions.put(key, value);
         callbackContext.success("custom dimension started");
     }
@@ -153,7 +157,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         //the common setCustomDimension (int index, String dimension) method
         try {
             Method builderMethod = builder.getClass().getMethod("setCustomDimension", Integer.TYPE, String.class);
-	    	
+
             for (Entry<Integer, String> entry : customDimensions.entrySet()) {
 	            Integer key = entry.getKey();
 	            String value = entry.getValue();
@@ -177,10 +181,10 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
         if (null != screenname && screenname.length() > 0) {
             tracker.setScreenName(screenname);
-            
+
             HitBuilders.ScreenViewBuilder hitBuilder = new HitBuilders.ScreenViewBuilder();
             addCustomDimensionsToHitBuilder(hitBuilder);
-            
+
             tracker.send(hitBuilder.build());
             callbackContext.success("Track Screen: " + screenname);
         } else {
@@ -197,7 +201,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         if (null != category && category.length() > 0) {
             HitBuilders.EventBuilder hitBuilder = new HitBuilders.EventBuilder();
             addCustomDimensionsToHitBuilder(hitBuilder);
-            
+
             tracker.send(hitBuilder
                     .setCategory(category)
                     .setAction(action)
@@ -228,7 +232,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             callbackContext.error("Expected integer key: " + key + ", and string value: " + value);
         }
     }
-    
+
     private void trackException(String description, Boolean fatal, CallbackContext callbackContext) {
         if (! trackerStarted ) {
             callbackContext.error("Tracker not started");
@@ -238,7 +242,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         if (null != description && description.length() > 0) {
             HitBuilders.ExceptionBuilder hitBuilder = new HitBuilders.ExceptionBuilder();
             addCustomDimensionsToHitBuilder(hitBuilder);
-        	
+
             tracker.send(hitBuilder
                     .setDescription(description)
                     .setFatal(fatal)
@@ -259,7 +263,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         if (null != category && category.length() > 0) {
             HitBuilders.TimingBuilder hitBuilder = new HitBuilders.TimingBuilder();
             addCustomDimensionsToHitBuilder(hitBuilder);
-        	
+
             tracker.send(hitBuilder
                     .setCategory(category)
                     .setValue(intervalInMilliseconds)
@@ -282,7 +286,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         if (null != id && id.length() > 0) {
             HitBuilders.TransactionBuilder hitBuilder = new HitBuilders.TransactionBuilder();
             addCustomDimensionsToHitBuilder(hitBuilder);
-        	
+
             tracker.send(hitBuilder
                     .setTransactionId(id)
                     .setAffiliation(affiliation)
@@ -339,7 +343,17 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         tracker.set("&uid", userId);
         callbackContext.success("Set user id" + userId);
     }
-    
+
+    private void setAppVersion(String version, CallbackContext callbackContext) {
+        if (! trackerStarted ) {
+            callbackContext.error("Tracker not started");
+            return;
+        }
+
+        tracker.set("&av", version);
+        callbackContext.success("Set app version: " + version);
+    }
+
     private void enableUncaughtExceptionReporting(Boolean enable, CallbackContext callbackContext) {
         if (! trackerStarted ) {
             callbackContext.error("Tracker not started");

--- a/ios/UniversalAnalyticsPlugin.h
+++ b/ios/UniversalAnalyticsPlugin.h
@@ -13,6 +13,7 @@
 
 - (void) startTrackerWithId: (CDVInvokedUrlCommand*)command;
 - (void) setUserId: (CDVInvokedUrlCommand*)command;
+- (void) setAppVersion: (CDVInvokedUrlCommand*)command;
 - (void) debugMode: (CDVInvokedUrlCommand*)command;
 - (void) enableUncaughtExceptionReporting: (CDVInvokedUrlCommand*)command;
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command;

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -67,19 +67,37 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) setAppVersion: (CDVInvokedUrlCommand*)command
+{
+  CDVPluginResult* pluginResult = nil;
+  NSString* version = [command.arguments objectAtIndex:0];
+
+  if ( ! _trackerStarted) {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Tracker not started"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    return;
+  }
+
+  id<GAITracker> tracker = [[GAI sharedInstance] defaultTracker];
+  [tracker set:@"&av" value: version];
+
+  pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void) enableUncaughtExceptionReporting: (CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    
+
     if ( ! _trackerStarted) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Tracker not started"];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
-    
+
     bool enabled = [[command.arguments objectAtIndex:0] boolValue];
     [[GAI sharedInstance] setTrackUncaughtExceptions:enabled];
-    
+
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/lavaca/AnalyticsService.js
+++ b/lavaca/AnalyticsService.js
@@ -48,6 +48,9 @@ define(function(require) {
     setUserId: function() {
       throw 'setUserId is not implemented for Lavaca';
     },
+    setAppVersion: function() {
+      throw 'setAppVersion is not implemented for Lavaca';
+    },
     debugMode: function() {
       throw 'debugMode is not implemented for Lavaca';
     },

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -8,6 +8,10 @@ UniversalAnalyticsPlugin.prototype.setUserId = function(id, success, error) {
   cordova.exec(success, error, 'UniversalAnalytics', 'setUserId', [id]);
 };
 
+UniversalAnalyticsPlugin.prototype.setAppVersion = function(version, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'setAppVersion', [version]);
+};
+
 /* enables verbose logging */
 UniversalAnalyticsPlugin.prototype.debugMode = function(success, error) {
   cordova.exec(success, error, 'UniversalAnalytics', 'debugMode', []);


### PR DESCRIPTION
as discussed in #206.

why? some apps use over the air updates and therefore can't change the app's native version.


little test outcome of setting it to `0.1.1`:
![set-app-version-manually](https://cloud.githubusercontent.com/assets/1093032/16708313/ab81cc6c-45ee-11e6-92f9-ac0b4ca8e6d8.png)
