### PR TITLE
deepLinkUrl is set to NSNull

### DIFF
--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -279,7 +279,7 @@
         NSString* deepLinkUrl = [command.arguments objectAtIndex:1];
         GAIDictionaryBuilder* openParams = [[GAIDictionaryBuilder alloc] init];
     
-        if (deepLinkUrl) {
+        if (deepLinkUrl && deepLinkUrl != (NSString *)[NSNull null]) {
             [[openParams setCampaignParametersFromUrl:deepLinkUrl] build];
         }
         


### PR DESCRIPTION
I'm using ionic-native GoogleAnalytics which proxies to cordova-plugin-google-analytics.  In this setup the campaignUrl cannot be set; however, that seems to make deepLinkUrl a NSNull which than fails (or erroneously passes) this if statement because you are looking for nil not NSNull