### PR TITLE
Possible crash fix for addCustomDimension*

### DIFF
--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -56,7 +56,7 @@
         NSString *value = [_customDimensions objectForKey:key];
 
         /* NSLog(@"Setting tracker dimension slot %@: <%@>", key, value); */
-        [tracker set:[GAIFields customDimensionForIndex:[key.intValue]]
+        [tracker set:[GAIFields customDimensionForIndex:[NSNumber key.intValue]]
         value:value];
       }
     }

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -60,7 +60,7 @@
         NSNumber *myKey = [f numberFromString:@"42"];
 
         /* NSLog(@"Setting tracker dimension slot %@: <%@>", key, value); */
-        [tracker set:[GAIFields customDimensionForIndex:myKey]
+        [tracker set:[GAIFields customDimensionForIndex:myKey.unsignedIntegerValue]
         value:value];
       }
     }

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -159,7 +159,7 @@
 - (void) addCustomDimension: (CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    NSString* key = [command.arguments objectAtIndex:0];
+    NSNumber* key = [command.arguments objectAtIndex:0];
     NSString* value = [command.arguments objectAtIndex:1];
 
     if ( ! _customDimensions) {

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -55,8 +55,12 @@
       for (NSString *key in _customDimensions) {
         NSString *value = [_customDimensions objectForKey:key];
 
+        NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
+        f.numberStyle = NSNumberFormatterDecimalStyle;
+        NSNumber *myKey = [f numberFromString:@"42"];
+
         /* NSLog(@"Setting tracker dimension slot %@: <%@>", key, value); */
-        [tracker set:[GAIFields customDimensionForIndex:[NSNumber key.intValue]]
+        [tracker set:[GAIFields customDimensionForIndex:myKey]
         value:value];
       }
     }

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -52,11 +52,11 @@
 - (void) addCustomDimensionsToTracker: (id<GAITracker>)tracker
 {
     if (_customDimensions) {
-      for (NSNumber *key in _customDimensions) {
+      for (NSString *key in _customDimensions) {
         NSString *value = [_customDimensions objectForKey:key];
 
         /* NSLog(@"Setting tracker dimension slot %@: <%@>", key, value); */
-        [tracker set:[GAIFields customDimensionForIndex:[key intValue]]
+        [tracker set:[GAIFields customDimensionForIndex:[key.intValue]]
         value:value];
       }
     }
@@ -166,7 +166,7 @@
       _customDimensions = [[NSMutableDictionary alloc] init];
     }
 
-    _customDimensions[key] = value;
+    _customDimensions[key.stringValue] = value;
 
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -52,7 +52,7 @@
 - (void) addCustomDimensionsToTracker: (id<GAITracker>)tracker
 {
     if (_customDimensions) {
-      for (NSString *key in _customDimensions) {
+      for (NSString *key in _customDimensions.allKeys) {
         NSString *value = [_customDimensions objectForKey:key];
 
         NSNumberFormatter *f = [[NSNumberFormatter alloc] init];

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -46,6 +46,7 @@ UniversalAnalyticsPlugin.prototype.trackView = function(screen, campaingUrl, new
 };
 
 UniversalAnalyticsPlugin.prototype.addCustomDimension = function(key, value, success, error) {
+    console.log('[addCustomDimension]', typeof key, key, typeof values, value, );
   if (typeof key !== "number") {
     throw Error("key must be a valid integer");
   }

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -46,9 +46,8 @@ UniversalAnalyticsPlugin.prototype.trackView = function(screen, campaingUrl, new
 };
 
 UniversalAnalyticsPlugin.prototype.addCustomDimension = function(key, value, success, error) {
-    console.log('[addCustomDimension]', typeof key, key, typeof values, value, );
   if (typeof key !== "number") {
-    throw Error("key must be a valid integer");
+    throw Error("key must be a valid integer not '" + typeof key + "'");
   }
   cordova.exec(success, error, 'UniversalAnalytics', 'addCustomDimension', [key, value]);
 };

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -46,6 +46,9 @@ UniversalAnalyticsPlugin.prototype.trackView = function(screen, campaingUrl, new
 };
 
 UniversalAnalyticsPlugin.prototype.addCustomDimension = function(key, value, success, error) {
+  if (typeof key !== "number") {
+    throw Error("key must be a valid integer");
+  }
   cordova.exec(success, error, 'UniversalAnalytics', 'addCustomDimension', [key, value]);
 };
 


### PR DESCRIPTION
purpose is to align the incoming values to be Numbers - as per Java. So that Js function call is the same.

Convert the number to string for internal storage inside the _customDimension dict
Then convert back to NSNumber for pass to GA SDK call

Needs some testing.... But certainly compiles ok on ios 10.