### PR TITLE
fix: remove extra/undesired logging

### DIFF
--- a/browser/UniversalAnalyticsProxy.js
+++ b/browser/UniversalAnalyticsProxy.js
@@ -195,7 +195,6 @@ function bindAll(that, names) {
 function loadGoogleAnalytics(name) {
   window['GoogleAnalyticsObject'] = name;
   window[name] = window[name] || function () {
-    console.log(arguments);
     (window[name].q = window[name].q || []).push(arguments)
   };
   var script = document.createElement('script');


### PR DESCRIPTION
Hi,

_According to @victorsosa 's request here: https://github.com/danwilson/google-analytics-plugin/pull/327#issuecomment-264702260._

Removes extra/undesired logging (as not taking value of `_isDebug` into account).

Thanks, guys!

Regards
Vincent