### PR TITLE
remove ad framework dependencies

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,6 @@
     <header-file src="ios/UniversalAnalyticsPlugin.h" />
     <source-file src="ios/UniversalAnalyticsPlugin.m" />
     <source-file src="ios/libGoogleAnalyticsServices.a" framework="true" />
-    <source-file src="ios/libAdIdAccess.a" framework="true" />
     <header-file src="ios/GAIDictionaryBuilder.h" />
     <header-file src="ios/GAIFields.h" />
     <header-file src="ios/GAILogger.h" />
@@ -45,7 +44,6 @@
 
     <framework src="SystemConfiguration.framework" />
     <framework src="CoreData.framework" />
-    <framework src="AdSupport.framework" />
     <framework src="libz.dylib" />
     <framework src="libsqlite3.dylib" />
   </platform>


### PR DESCRIPTION
Based on this issue: https://github.com/danwilson/google-analytics-plugin/issues/218 and one of the fixes I just did this.

I don't know if these files are used, but if they aren't then this PR could just be merged in I suppose.