### PR TITLE
fix: (browser) async loading of analytics.js updates this._nativeGa

### DIFF
--- a/browser/UniversalAnalyticsProxy.js
+++ b/browser/UniversalAnalyticsProxy.js
@@ -2,7 +2,9 @@ function UniversalAnalyticsProxy() {
   this._isDebug = false;
   this._isEcommerceRequired = false;
   this._trackingId = null;
-  this._nativeGa = loadGoogleAnalytics(window['GoogleAnalyticsObject'] || 'nativeGa');
+
+  var namespace = window.GoogleAnalyticsObject || 'nativeGa';
+  loadGoogleAnalytics.call(this, namespace);
 
   bindAll(this, [
     '_ensureEcommerce',
@@ -192,18 +194,30 @@ function bindAll(that, names) {
   });
 }
 
+/**
+ * Proceed to the asynchronous loading of Google's analytics.js.
+ * Initialize `this._nativeGa` once the script is loaded, using
+ * the `onload` callback of the `script` DOM node.
+ *
+ * @param {string} name Reference (global namespace) of the GA object.
+ */
 function loadGoogleAnalytics(name) {
-  window['GoogleAnalyticsObject'] = name;
+  window.GoogleAnalyticsObject = name;
+
   window[name] = window[name] || function () {
-    console.log(arguments);
-    (window[name].q = window[name].q || []).push(arguments)
+    (window[name].q = window[name].q || []).push(arguments);
   };
+  window[name].l = 1 * new Date();
+  this._nativeGa = window[name];
+
   var script = document.createElement('script');
   var scripts = document.getElementsByTagName('script')[0];
   script.src = 'https://www.google-analytics.com/analytics.js';
   script.async = 1;
   scripts.parentNode.insertBefore(script, scripts);
-  return window[name];
+
+  // analytics.js creates a new object once initialized, update our reference
+  script.onload = (function() { this._nativeGa = window[name]; }).bind(this);
 }
 
 function wrap(fn) {


### PR DESCRIPTION
Hi guys,

The plugin is not working on platform `browser` as the current code does not update the reference to Google Analytics object (`this._nativeGa`) when analytics.js finally initializes it.

Here's my proposition for a fix.
This cannot be auto-merged but the changes are pretty basic.

Thanks again for the hard work!

EDIT - The issue was described here https://github.com/danwilson/google-analytics-plugin/issues/327 and here https://github.com/danwilson/google-analytics-plugin/issues/357

Regards,
Vincent.