### PR TITLE
Callback for setAllowIDFACollection on ios

### DIFF
--- a/ios/UniversalAnalyticsPlugin.m
+++ b/ios/UniversalAnalyticsPlugin.m
@@ -47,6 +47,9 @@
     
     id<GAITracker> tracker = [[GAI sharedInstance] defaultTracker];
     tracker.allowIDFACollection = [[command argumentAtIndex:0 withDefault:@(NO)] boolValue];
+
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) addCustomDimensionsToTracker: (id<GAITracker>)tracker


### PR DESCRIPTION
The callback for setAllowIDFACollection is not being invoked by the iOS driver. A client waiting for it would hang indefinitely.

