### PR TITLE
enabled dryRun on debugMode for Android platform…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ To enabling Advertising Features in Google Analytics allows you to take advantag
 
 To enable verbose logging:
 * `window.ga.debugMode()`
+* set's dry run mode on Android and Windows platform, so that all hits are only echoed back by the google analytics service and no actual hit is getting tracked!
 * **Android quirk**: verbose logging within javascript console is not supported. To see debug responses from analytics execute 
 `adb shell setprop log.tag.GAv4 DEBUG` and then `adb logcat -v time -s GAv4` to list messages 
 (see [Android SDK Documentation on deprected Logger class](https://developers.google.com/android/reference/com/google/android/gms/analytics/Logger))

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ To enabling Advertising Features in Google Analytics allows you to take advantag
 
 To enable verbose logging:
 * `window.ga.debugMode()`
+* **Android quirk**: verbose logging within javascript console is not supported. To see debug responses from analytics execute 
+`adb shell setprop log.tag.GAv4 DEBUG` and then `adb logcat -v time -s GAv4` to list messages 
+(see [Android SDK Documentation on deprected Logger class](https://developers.google.com/android/reference/com/google/android/gms/analytics/Logger))
 
 To enable/disable automatic reporting of uncaught exceptions
 * `window.ga.enableUncaughtExceptionReporting(Enable, success, error)` where Enable is boolean

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -411,7 +411,12 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
     }    
 
     private void debugMode(CallbackContext callbackContext) {
-        GoogleAnalytics.getInstance(this.cordova.getActivity()).getLogger().setLogLevel(LogLevel.VERBOSE);
+        // GAv4 Logger is deprecated!
+        // GoogleAnalytics.getInstance(this.cordova.getActivity()).getLogger().setLogLevel(LogLevel.VERBOSE);
+        
+        // To enable verbose logging execute "adb shell setprop log.tag.GAv4 DEBUG"
+        // and then "adb logcat -v time -s GAv4" to inspect log entries.
+        GoogleAnalytics.getInstance(this.cordova.getActivity()).setDryRun(true);
 
         this.debugModeEnabled = true;
         callbackContext.success("debugMode enabled");


### PR DESCRIPTION
…so that reported hits are only echoed back and not tracked as real hits.
Also commented out setLoglevel because of deprecated Logger class and added hint to readme.md on how to enable verbose logging via adb shell.

perhaps some time in the future the Browser platform should enable dry run also, but for this another CDN has to be loaded - see [Google Analytics SDK for Javascript Debugging Documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging)..