### PR TITLE
added possibility to unset custom dimension/metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ window.ga.trackEvent('Category', 'Action', 'Label', Value, true)// Label, Value 
 //(trackMetric doesn't actually send a hit, it's behaving more like the addCustomDimension() method.
 // The metric is afterwards added to every hit (view, event, error, etc...) sent, but the defined scope of the custom metric in analytics backend
 //   (hit or product) will determine, at processing time, which hits are associated with the metric value.)
-window.ga.trackMetric(Key, Value) // Key and value are numeric type
+window.ga.trackMetric(Key, Value) // Key and value are numeric type, Value is optional (omit value to unset metric)
 
 //To track an Exception:
 window.ga.trackException('Description', Fatal)//where Fatal is boolean
@@ -98,6 +98,7 @@ window.ga.addTransactionItem('ID', 'Name', 'SKU', 'Category', Price, Quantity, '
 //   (hit or product) will determine, at processing time, which hits are associated with the dimension value.)
 window.ga.addCustomDimension(Key, 'Value', success, error)
 //Key should be integer index of the dimension i.e. send `1` instead of `dimension1` for the first custom dimension you are tracking. e.g. `window.ga.addCustomDimension(1, 'Value', success, error)`
+//Use empty string as value to unset custom dimension.
 
 //To set a UserId:
 window.ga.setUserId('my-user-id')

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -55,18 +55,15 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         } else if (TRACK_VIEW.equals(action)) {
             int length = args.length();
             String screen = args.getString(0);
-            this.trackView(screen, length > 1 && !args.isNull(1) ? args.getString(1) : "", length > 2 && !args.isNull(2) ? args.getBoolean(2) : false, callbackContext);
+            this.trackView(screen, length > 1 && !args.isNull(1) ? args.getString(1) : "",
+                    length > 2 && !args.isNull(2) ? args.getBoolean(2) : false, callbackContext);
             return true;
         } else if (TRACK_EVENT.equals(action)) {
             int length = args.length();
             if (length > 0) {
-                this.trackEvent(
-                        args.getString(0),
-                        length > 1 ? args.getString(1) : "",
-                        length > 2 ? args.getString(2) : "",
-                        length > 3 ? args.getLong(3) : 0,
-                        length > 4 ? args.getBoolean(4) : false,
-                        callbackContext);
+                this.trackEvent(args.getString(0), length > 1 ? args.getString(1) : "",
+                        length > 2 ? args.getString(2) : "", length > 3 ? args.getLong(3) : 0,
+                        length > 4 ? args.getBoolean(4) : false, callbackContext);
             }
             return true;
         } else if (TRACK_EXCEPTION.equals(action)) {
@@ -77,7 +74,8 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         } else if (TRACK_TIMING.equals(action)) {
             int length = args.length();
             if (length > 0) {
-                this.trackTiming(args.getString(0), length > 1 ? args.getLong(1) : 0, length > 2 ? args.getString(2) : "", length > 3 ? args.getString(3) : "", callbackContext);
+                this.trackTiming(args.getString(0), length > 1 ? args.getLong(1) : 0,
+                        length > 2 ? args.getString(2) : "", length > 3 ? args.getString(3) : "", callbackContext);
             }
             return true;
         } else if (TRACK_METRIC.equals(action)) {
@@ -94,28 +92,18 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         } else if (ADD_TRANSACTION.equals(action)) {
             int length = args.length();
             if (length > 0) {
-                this.addTransaction(
-                        args.getString(0),
-                        length > 1 ? args.getString(1) : "",
-                        length > 2 ? args.getDouble(2) : 0,
-                        length > 3 ? args.getDouble(3) : 0,
-                        length > 4 ? args.getDouble(4) : 0,
-                        length > 5 ? args.getString(5) : null,
-                        callbackContext);
+                this.addTransaction(args.getString(0), length > 1 ? args.getString(1) : "",
+                        length > 2 ? args.getDouble(2) : 0, length > 3 ? args.getDouble(3) : 0,
+                        length > 4 ? args.getDouble(4) : 0, length > 5 ? args.getString(5) : null, callbackContext);
             }
             return true;
         } else if (ADD_TRANSACTION_ITEM.equals(action)) {
             int length = args.length();
             if (length > 0) {
-                this.addTransactionItem(
-                        args.getString(0),
-                        length > 1 ? args.getString(1) : "",
-                        length > 2 ? args.getString(2) : "",
-                        length > 3 ? args.getString(3) : "",
-                        length > 4 ? args.getDouble(4) : 0,
-                        length > 5 ? args.getLong(5) : 0,
-                        length > 6 ? args.getString(6) : null,
-                        callbackContext);
+                this.addTransactionItem(args.getString(0), length > 1 ? args.getString(1) : "",
+                        length > 2 ? args.getString(2) : "", length > 3 ? args.getString(3) : "",
+                        length > 4 ? args.getDouble(4) : 0, length > 5 ? args.getLong(5) : 0,
+                        length > 6 ? args.getString(6) : null, callbackContext);
             }
             return true;
         } else if (SET_ALLOW_IDFA_COLLECTION.equals(action)) {
@@ -134,15 +122,15 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             this.setAppVersion(version, callbackContext);
         } else if (GET_VAR.equals(action)) {
             String variable = args.getString(0);
-            this.getVar(variable, callbackContext);           
+            this.getVar(variable, callbackContext);
         } else if (SET_VAR.equals(action)) {
             String variable = args.getString(0);
             String value = args.getString(1);
-            this.setVar(variable, value, callbackContext);               
+            this.setVar(variable, value, callbackContext);
             return true;
         } else if (DISPATCH.equals(action)) {
-            this.dispatch(callbackContext);               
-            return true;            
+            this.dispatch(callbackContext);
+            return true;
         } else if (DEBUG_MODE.equals(action)) {
             this.debugMode(callbackContext);
         } else if (ENABLE_UNCAUGHT_EXCEPTION_REPORTING.equals(action)) {
@@ -170,12 +158,13 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         }
 
         if (null == value || value.length() == 0) {
-            callbackContext.error("Expected non-empty string argument for value.");
-            return;
+            // unset dimension
+            customDimensions.remove(key);
+            callbackContext.success("custom dimension stopped");    
+        } else {
+            customDimensions.put(key, value);
+            callbackContext.success("custom dimension started");
         }
-
-        customDimensions.put(key, value);
-        callbackContext.success("custom dimension started");
     }
 
     private <T> void addCustomDimensionsAndMetricsToHitBuilder(T builder) {
@@ -217,7 +206,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
     }
 
     private void trackView(String screenname, String campaignUrl, boolean newSession, CallbackContext callbackContext) {
-        if (! trackerStarted ) {
+        if (!trackerStarted) {
             callbackContext.error("Tracker not started");
             return;
         }
@@ -228,23 +217,24 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             HitBuilders.ScreenViewBuilder hitBuilder = new HitBuilders.ScreenViewBuilder();
             addCustomDimensionsAndMetricsToHitBuilder(hitBuilder);
 
-            if(!campaignUrl.equals("")){
+            if (!campaignUrl.equals("")) {
                 hitBuilder.setCampaignParamsFromUrl(campaignUrl);
             }
-            
-            if(!newSession) {
+
+            if (!newSession) {
                 tracker.send(hitBuilder.build());
             } else {
                 tracker.send(hitBuilder.setNewSession().build());
             }
-                    
+
             callbackContext.success("Track Screen: " + screenname);
         } else {
             callbackContext.error("Expected one non-empty string argument.");
         }
     }
 
-    private void trackEvent(String category, String action, String label, long value, boolean newSession, CallbackContext callbackContext) {
+    private void trackEvent(String category, String action, String label, long value, boolean newSession,
+            CallbackContext callbackContext) {
         if (!trackerStarted) {
             callbackContext.error("Tracker not started");
             return;
@@ -254,23 +244,14 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             HitBuilders.EventBuilder hitBuilder = new HitBuilders.EventBuilder();
             addCustomDimensionsAndMetricsToHitBuilder(hitBuilder);
 
-            if(!newSession){
-                tracker.send(hitBuilder
-                        .setCategory(category)
-                        .setAction(action)
-                        .setLabel(label)
-                        .setValue(value)
-                        .build());
+            if (!newSession) {
+                tracker.send(
+                        hitBuilder.setCategory(category).setAction(action).setLabel(label).setValue(value).build());
             } else {
-                tracker.send(hitBuilder
-                        .setCategory(category)
-                        .setAction(action)
-                        .setLabel(label)
-                        .setValue(value)
-                        .setNewSession()
-                        .build());                
+                tracker.send(hitBuilder.setCategory(category).setAction(action).setLabel(label).setValue(value)
+                        .setNewSession().build());
             }
-            
+
             callbackContext.success("Track Event: " + category);
         } else {
             callbackContext.error("Expected non-empty string arguments.");
@@ -284,20 +265,21 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         }
 
         if (null == value || value.length() == 0) {
-            callbackContext.error("Expected non-empty string argument for value.");
-            return;
-        }
+            // unset metric
+            customMetrics.remove(key);
+            callbackContext.success("custom metric stopped");
+        } else {
+            Float floatValue;
+            try {
+                floatValue = Float.parseFloat(value);
+            } catch (NumberFormatException e) {
+                callbackContext.error("Expected string formatted number for value.");
+                return;
+            }
 
-        Float floatValue;
-        try {
-            floatValue = Float.parseFloat(value);
-        } catch (NumberFormatException e) {
-            callbackContext.error("Expected string formatted number for value.");
-            return;
+            customMetrics.put(key, floatValue);
+            callbackContext.success("custom metric started");
         }
-
-        customMetrics.put(key, floatValue);
-        callbackContext.success("custom metric started");
     }
 
     private void trackException(String description, Boolean fatal, CallbackContext callbackContext) {
@@ -310,18 +292,15 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             HitBuilders.ExceptionBuilder hitBuilder = new HitBuilders.ExceptionBuilder();
             addCustomDimensionsAndMetricsToHitBuilder(hitBuilder);
 
-            tracker.send(hitBuilder
-                    .setDescription(description)
-                    .setFatal(fatal)
-                    .build()
-            );
+            tracker.send(hitBuilder.setDescription(description).setFatal(fatal).build());
             callbackContext.success("Track Exception: " + description);
         } else {
             callbackContext.error("Expected non-empty string arguments.");
         }
     }
 
-    private void trackTiming(String category, long intervalInMilliseconds, String name, String label, CallbackContext callbackContext) {
+    private void trackTiming(String category, long intervalInMilliseconds, String name, String label,
+            CallbackContext callbackContext) {
         if (!trackerStarted) {
             callbackContext.error("Tracker not started");
             return;
@@ -331,20 +310,16 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             HitBuilders.TimingBuilder hitBuilder = new HitBuilders.TimingBuilder();
             addCustomDimensionsAndMetricsToHitBuilder(hitBuilder);
 
-            tracker.send(hitBuilder
-                    .setCategory(category)
-                    .setValue(intervalInMilliseconds)
-                    .setVariable(name)
-                    .setLabel(label)
-                    .build()
-            );
+            tracker.send(hitBuilder.setCategory(category).setValue(intervalInMilliseconds).setVariable(name)
+                    .setLabel(label).build());
             callbackContext.success("Track Timing: " + category);
         } else {
             callbackContext.error("Expected non-empty string arguments.");
         }
     }
 
-    private void addTransaction(String id, String affiliation, double revenue, double tax, double shipping, String currencyCode, CallbackContext callbackContext) {
+    private void addTransaction(String id, String affiliation, double revenue, double tax, double shipping,
+            String currencyCode, CallbackContext callbackContext) {
         if (!trackerStarted) {
             callbackContext.error("Tracker not started");
             return;
@@ -354,21 +329,16 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             HitBuilders.TransactionBuilder hitBuilder = new HitBuilders.TransactionBuilder();
             addCustomDimensionsAndMetricsToHitBuilder(hitBuilder);
 
-            tracker.send(hitBuilder
-                    .setTransactionId(id)
-                    .setAffiliation(affiliation)
-                    .setRevenue(revenue).setTax(tax)
-                    .setShipping(shipping)
-                    .setCurrencyCode(currencyCode)
-                    .build()
-            ); //Deprecated
+            tracker.send(hitBuilder.setTransactionId(id).setAffiliation(affiliation).setRevenue(revenue).setTax(tax)
+                    .setShipping(shipping).setCurrencyCode(currencyCode).build()); //Deprecated
             callbackContext.success("Add Transaction: " + id);
         } else {
             callbackContext.error("Expected non-empty ID.");
         }
     }
 
-    private void addTransactionItem(String id, String name, String sku, String category, double price, long quantity, String currencyCode, CallbackContext callbackContext) {
+    private void addTransactionItem(String id, String name, String sku, String category, double price, long quantity,
+            String currencyCode, CallbackContext callbackContext) {
         if (!trackerStarted) {
             callbackContext.error("Tracker not started");
             return;
@@ -378,16 +348,8 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             HitBuilders.ItemBuilder hitBuilder = new HitBuilders.ItemBuilder();
             addCustomDimensionsAndMetricsToHitBuilder(hitBuilder);
 
-            tracker.send(hitBuilder
-                    .setTransactionId(id)
-                    .setName(name)
-                    .setSku(sku)
-                    .setCategory(category)
-                    .setPrice(price)
-                    .setQuantity(quantity)
-                    .setCurrencyCode(currencyCode)
-                    .build()
-            ); //Deprecated
+            tracker.send(hitBuilder.setTransactionId(id).setName(name).setSku(sku).setCategory(category).setPrice(price)
+                    .setQuantity(quantity).setCurrencyCode(currencyCode).build()); //Deprecated
             callbackContext.success("Add Transaction Item: " + id);
         } else {
             callbackContext.error("Expected non-empty ID.");
@@ -412,7 +374,8 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
         tracker.set(variable, value);
         callbackContext.success("Set variable " + variable + "to " + value);
-    }  
+    }
+
     private void dispatch(CallbackContext callbackContext) {
         if (!trackerStarted) {
             callbackContext.error("Tracker not started");
@@ -421,7 +384,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
         GoogleAnalytics.getInstance(this.cordova.getActivity()).dispatchLocalHits();
         callbackContext.success("dispatch sent");
-    }     
+    }
 
     private void getVar(String variable, CallbackContext callbackContext) {
         if (!trackerStarted) {
@@ -431,12 +394,12 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
 
         String result = tracker.get(variable);
         callbackContext.success(result);
-    }    
+    }
 
     private void debugMode(CallbackContext callbackContext) {
         // GAv4 Logger is deprecated!
         // GoogleAnalytics.getInstance(this.cordova.getActivity()).getLogger().setLogLevel(LogLevel.VERBOSE);
-        
+
         // To enable verbose logging execute "adb shell setprop log.tag.GAv4 DEBUG"
         // and then "adb logcat -v time -s GAv4" to inspect log entries.
         GoogleAnalytics.getInstance(this.cordova.getActivity()).setDryRun(true);

--- a/typescript/analytics.d.ts
+++ b/typescript/analytics.d.ts
@@ -32,7 +32,7 @@ declare class UniversalAnalyticsPlugin {
 	public debugMode(successCallback?:Function, errorCallback?:Function):void;
 
 	/** Track a Custom Metric */
-	public trackMetric(key:number, value:number, successCallback?:Function, errorCallback?:Function):void;
+	public trackMetric(key:number, value?:number, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Track a Screen (PageView) */
 	public trackView(screen:String, campaignUrl?:string, newSession?:boolean, successCallback?:Function, errorCallback?:Function):void;

--- a/windows/GoogleAnalyticsProxy.js
+++ b/windows/GoogleAnalyticsProxy.js
@@ -86,7 +86,7 @@ function addCustomDimensionsAndMetrics(hitBuilder) {
                 hitBuilder = hitBuilder.setCustomDimension(key, _customDimensions[key]);
             }
         }
-        
+
         // add previously added custom metrics
         for (var key in _customMetrics) {
             if (_customMetrics.hasOwnProperty(key)) {
@@ -235,26 +235,28 @@ module.exports = {
             fail("Expected positive numeric integer argument");
             return;
         }
-        
-        if (args.length < 1) {
-            fail("Expected second argument");
-            return;
-        }        
-        var value = args[1];
-        if (typeof args[1] !== "number") {
-            if (typeof args[1] !== "string") {
-                fail("Expected either numeric or string formatted number argument");
-                return;
-            }
-            value = Number.parseFloat(args[1]);
-            if (isNaN(value)) {
-                fail("Expected either numeric or string formatted number argument");
-                return;
-            }
-        }
 
-        _customMetrics[args[0]] = value;
-        win();
+        if (args.length < 1 || args[1] === null || typeof args[1] === "undefined" || args[1] === "") {
+            // unset metric
+            delete _customMetrics[args[0]];
+            win("custom metric stopped");
+        } else {
+            var value = args[1];
+            if (typeof args[1] !== "number") {
+                if (typeof args[1] !== "string") {
+                    fail("Expected either numeric or string formatted number argument");
+                    return;
+                }
+                value = Number.parseFloat(args[1]);
+                if (isNaN(value)) {
+                    fail("Expected either numeric or string formatted number argument");
+                    return;
+                }
+            }
+
+            _customMetrics[args[0]] = value;
+            win("custom metric started");
+        }
     },
 
     addCustomDimension: function (win, fail, args) {
@@ -263,13 +265,14 @@ module.exports = {
             return;
         }
 
-        if (args.length < 1 || args[1] === "") {
-            fail("Expected non empty string argument");
-            return;
+        if (args.length < 1 || args[1] === null || typeof args[1] === "undefined" || args[1] === "") {
+            // unset dimension
+            delete _customDimensions[args[0]];
+            win("custom dimension stopped");
+        } else {
+            _customDimensions[args[0]] = args[1];
+            win("custom dimension started");
         }
-
-        _customDimensions[args[0]] = args[1];
-        win();
     },
 
     addTransaction: function (win, fail, args) {

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -64,8 +64,8 @@ UniversalAnalyticsPlugin.prototype.trackMetric = function(key, value, success, e
   // as value was formerly documented to be of type string
   // and therefore platform implementations expect value parameter of type string,
   // we need to cast the value parameter to string - although gathered metrics are infact number types.
-  var stringValue = value;
-  if (typeof value !== "string") {
+  var stringValue = value || "";
+  if (typeof stringValue !== "string") {
     stringValue = String(value);
   }
   cordova.exec(success, error, 'UniversalAnalytics', 'trackMetric', [numberKey, stringValue]);


### PR DESCRIPTION
As pointed out in https://github.com/danwilson/google-analytics-plugin/issues/415 the custom dimensions and metrics could not be unset.
This is now possible via passing null or an empty string for value parameter in addCustomDimension or omit the value paramter in trackMetric.

Tested in Android emulator with debugMode with this code:
```javascript
public test() {
    this.platform.ready().then(() => {
      return this.ga.startTrackerWithId("UA-xxxxxxxx-x");
    }).then(() => {
      return this.ga.debugMode();
    }).then(() => {
      return this.ga.setAnonymizeIp(true);
    }).then(() => {
      return this.ga.enableUncaughtExceptionReporting(true);
    }).then(() => {
      return this.ga.addCustomDimension(1, "MyDimension");
    }).then(() => {
      // in Ionic 2 one has to currently use string formatted key
      return this.ga.trackMetric("1", 12.23);
    }).then(() => {
      return this.ga.trackView("HomePage");
    }).then(() => {
      return this.ga.trackEvent("HomePage", "AnalyticsInitialized", JSON.stringify(this.platform.platforms()));
    }).then(() => {
      return this.ga.trackTiming("HomePage", 1234, "InitDuration", "Timing");
    }).then(() => {
      return this.ga.trackException("You Fail!", false);
    }).then(() => {
      // unset dimension
      return this.ga.addCustomDimension(1, "");
    }).then(() => {
     // in Ionic 2 one has to currently use string formatted key
     // unset metric
      return this.ga.trackMetric("1");
    }).then(() => {
      return this.ga.trackEvent("HomePage", "UnsetCustomDimensionAndMetric");
    }).catch((err) => {
      console.error(err);
    });
  }
```

Echoe response from Google:
```
07-13 06:15:58.198 I/GAv4    ( 3724): Dry run enabled. Would have sent hit: ht=1499926558197, _v=ma11.0.20, a=61755579, aid=io.ionic.starter, aip=1, an=MyApp, av=0.0.1, cd=HomePage, cd1=MyDimension, cid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx, cm1=12.23, sr=1080x1794, t=screenview, tid=UA-xxxxxxxx-x, ul=en-us, v=1
07-13 06:15:58.199 I/GAv4    ( 3724): Dry run enabled. Would have sent hit: ht=1499926558198, _v=ma11.0.20, a=61755580, aid=io.ionic.starter, aip=1, an=MyApp, av=0.0.1, cd=HomePage, cd1=MyDimension, cid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx, cm1=12.23, ea=AnalyticsInitialized, ec=HomePage, el=["cordova","mobile","android","phablet"], ev=0, sr=1080x1794, t=event, tid=UA-xxxxxxxx-x, ul=en-us, v=1
07-13 06:15:58.200 I/GAv4    ( 3724): Dry run enabled. Would have sent hit: ht=1499926558200, _v=ma11.0.20, a=61755580, aid=io.ionic.starter, aip=1, an=MyApp, av=0.0.1, cd=HomePage, cd1=MyDimension, cid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx, cm1=12.23, sr=1080x1794, t=timing, tid=UA-xxxxxxxx-x, ul=en-us, utc=HomePage, utl=Timing, utt=1234, utv=InitDuration, v=1
07-13 06:15:58.201 I/GAv4    ( 3724): Dry run enabled. Would have sent hit: ht=1499926558201, _v=ma11.0.20, a=61755580, aid=io.ionic.starter, aip=1, an=MyApp, av=0.0.1, cd=HomePage, cd1=MyDimension, cid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx, cm1=12.23, exd=You Fail!, exf=0, sr=1080x1794, t=exception, tid=UA-xxxxxxxx-x, ul=en-us, v=1
07-13 06:15:58.208 I/GAv4    ( 3724): Dry run enabled. Would have sent hit: ht=1499926558207, _v=ma11.0.20, a=61755580, aid=io.ionic.starter, aip=1, an=MyApp, av=0.0.1, cd=HomePage, cid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx, ea=UnsetCustomDimensionAndMetric, ec=HomePage, el=, ev=0, sr=1080x1794, t=event, tid=UA-xxxxxxxx-x, ul=en-us, v=1
```

In the last hit data no more custom dimension and metric is tracked..