### PR TITLE
Ecommerce support for Windows 10 UWP

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ window.ga.enableUncaughtExceptionReporting(Enable, success, error)// where Enabl
 
   Just to send product impressions
 */
-window.ga.addImpression(screamName, product)
+window.ga.addImpression(screen, product)
 
 /**
   Product Action definitions:
@@ -182,7 +182,7 @@ window.ga.addImpression(screamName, product)
   Enhanced Ecommerce Tracking
   https://developers.google.com/analytics/devguides/collection/android/v4/enhanced-ecommerce  
 */
-window.ga.productAction(screamName, product, productAction)
+window.ga.productAction(screen, product, productAction)
 
 /**Promotion definitions:
     action field:
@@ -295,10 +295,17 @@ The following plugin methods are (currently) not supported by the UWP.SDKforGoog
 * `setAllowIDFACollection()`
 * `addTransaction()`
 * `addTransactionItem()`
+* `addImpression()`
 
 Unexpected behaviour may occur on the following methods:
 * `trackView()`: campaign details are currently not supported and therefore not tracked.
 * `trackMetric()`: there is currently a bug in version 1.5.2 of the [UWP.SDKforGoogleAnalytics.Native package via NuGet](http://nuget.org/packages/UWP.SDKforGoogleAnalytics.Native),
 that the wrong data specifier `cd` is taken for metrics, whereas `cm` should be the correct specifier.
-So as long as this bug is not fixed, trackMetrics will overwrite previous addCustomDimension with same index!!
+So as long as this bug is not fixed, trackMetrics() will overwrite previous addCustomDimension with same index!!
+* `productAction()`: there is currently a bug in version 1.5.2 of the [UWP.SDKforGoogleAnalytics.Native package via NuGet](http://nuget.org/packages/UWP.SDKforGoogleAnalytics.Native),
+that the wrong data specifier `at` is taken for product quantity, whereas `qt` should be the correct specifier.
+So as long as this bug is not fixed, productAction() will possibly not work correctly!!
+
+Pull Requests are already submitted. As long as these are not merged, you can clone the Fork from https://github.com/spacepope/windows-sdk-for-google-analytics and add the corresponding project reference to your UWP project instead of installing the current nuget package..
+
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ window.ga.productAction(screen, product, productAction)
     promotion.position = "position";
     promotion.creative = "creative"; 
 */
-window.ga.addPromotion(action, promotion, label, category)
+window.ga.addPromotion(action, promotion, category, label)
 
 //To add a Transaction (Ecommerce) -- Deprecated on 1.9.0 
 window.ga.addTransaction('ID', 'Affiliation', Revenue, Tax, Shipping, 'Currency Code')// where Revenue, Tax, and Shipping are numeric

--- a/android/UniversalAnalyticsPlugin.java
+++ b/android/UniversalAnalyticsPlugin.java
@@ -132,7 +132,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
             int length = args.length();
             this.addPromotion(args.getString(0), args.getJSONObject(1), 
                                     length > 2 ? args.getString(2) : "", 
-                                    length > 3 ? args.getString(3) : "",callbackContext);
+                                    length > 3 ? args.getString(3) : "", callbackContext);
             return true;
         } else if (SET_ALLOW_IDFA_COLLECTION.equals(action)) {
             this.setAllowIDFACollection(args.getBoolean(0), callbackContext);
@@ -588,7 +588,7 @@ public class UniversalAnalyticsPlugin extends CordovaPlugin {
         callbackContext.success("product action executed");      
     }
     
-    private void addPromotion(String action, JSONObject promotionInput, String label, String category,  CallbackContext callbackContext) {
+    private void addPromotion(String action, JSONObject promotionInput, String category, String label, CallbackContext callbackContext) {
         if (!trackerStarted) {
             callbackContext.error("Tracker not started");
             return;

--- a/typescript/analytics.d.ts
+++ b/typescript/analytics.d.ts
@@ -1,3 +1,49 @@
+export interface Product {
+	id: string;
+	name: string;
+	category?: string;
+	brand?: string;
+	variant?: string;
+	position?: number;
+	customDimension?: any[];
+	customMetric?: any[];
+	price?: number;
+	quantity?: number;
+	couponCode?: string;
+}
+
+export type ProductActionType = "ACTION_ADD" |
+						 "ACTION_CHECKOUT" |
+						 "ACTION_CHECKOUT_OPTION" |
+						 "ACTION_CHECKOUT_OPTIONS" |
+						 "ACTION_CLICK" |
+						 "ACTION_DETAIL" |
+						 "ACTION_PURCHASE" |
+						 "ACTION_REFUND" |
+						 "ACTION_REMOVE"
+
+export interface ProductAction {
+	action: ProductActionType;
+	transactionId?: string;
+	transactionRevenue?: number;
+	transactionCouponCode?: string;
+	transactionShipping?: number;
+	transactionTax?: number;
+	checkoutOptions?: string;
+	checkoutStep?: number;
+	transactionAffiliation?: string;
+}
+
+export interface Promotion {
+	id: string;
+	name: string;
+	position?: string;
+	creative?: string;
+}
+
+export type PromotionAction = "ACTION_CLICK" |
+					   "ACTION_VIEW"
+
 declare class UniversalAnalyticsPlugin {
 
 	/** In your 'deviceready' handler, call this to set up your Analytics tracker,
@@ -62,10 +108,10 @@ declare class UniversalAnalyticsPlugin {
 	/** Add a Transaction Item (Ecommerce) */
 	public addTransactionItem(transactionId:string, name:string, sku:string, category:string, price:number, quantity:number, currencyCode:string, successCallback?:Function, errorCallback?:Function):void;
 
-	public addImpression(screen:string, product:any, successCallback?:Function, errorCallback?:Function):void;
+	public addImpression(screen:string, product:Product, successCallback?:Function, errorCallback?:Function):void;
 
-	public productAction(screen:string, product:any, successCallback?:Function, errorCallback?:Function):void;
+	public productAction(screen:string, product:Product, productAction: ProductAction, successCallback?:Function, errorCallback?:Function):void;
 
-	public addPromotion(action:string, promotion:any, label?:string, category?:string, successCallback?:Function, errorCallback?:Function):void;
+	public addPromotion(action:PromotionAction, promotion:Promotion, category:string, label?:string, successCallback?:Function, errorCallback?:Function):void;
 
 }

--- a/typescript/analytics.d.ts
+++ b/typescript/analytics.d.ts
@@ -62,9 +62,9 @@ declare class UniversalAnalyticsPlugin {
 	/** Add a Transaction Item (Ecommerce) */
 	public addTransactionItem(transactionId:string, name:string, sku:string, category:string, price:number, quantity:number, currencyCode:string, successCallback?:Function, errorCallback?:Function):void;
 
-	public addImpression(screamName:string, product:any, successCallback?:Function, errorCallback?:Function):void;
+	public addImpression(screen:string, product:any, successCallback?:Function, errorCallback?:Function):void;
 
-	public productAction(screamName:string, product:any, successCallback?:Function, errorCallback?:Function):void;
+	public productAction(screen:string, product:any, successCallback?:Function, errorCallback?:Function):void;
 
 	public addPromotion(action:string, promotion:any, label?:string, category?:string, successCallback?:Function, errorCallback?:Function):void;
 

--- a/typescript/analytics.d.ts
+++ b/typescript/analytics.d.ts
@@ -2,19 +2,19 @@ declare class UniversalAnalyticsPlugin {
 
 	/** In your 'deviceready' handler, call this to set up your Analytics tracker,
 		where id is your Google Analytics Mobile App property */
-	public startTrackerWithId(id:String, dispatchPeriod?:Number, successCallback?:Function, errorCallback?:Function):void;
+	public startTrackerWithId(id:string, dispatchPeriod?:number, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Sets a UserId */
-	public setUserId(id:String, successCallback?:Function, errorCallback?:Function):void;
+	public setUserId(id:string, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Sets a setAnonymizeIp */
-	public setAnonymizeIp(anonymize:Boolean, successCallback?:Function, errorCallback?:Function):void;
+	public setAnonymizeIp(anonymize:boolean, successCallback?:Function, errorCallback?:Function):void;
 
     /** Sets a setOptOut */
-    public setOptOut(optout:Boolean, successCallback?:Function, errorCallback?:Function): void;
+    public setOptOut(optout:boolean, successCallback?:Function, errorCallback?:Function): void;
 
 	/** Sets a setAllowIDFACollection */
-	public setAllowIDFACollection(enable:Boolean, successCallback?:Function, errorCallback?:Function):void;
+	public setAllowIDFACollection(enable:boolean, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Sets a AppVersion */
 	public setAppVersion(version:string, successCallback?:Function, errorCallback?:Function):void;
@@ -35,37 +35,37 @@ declare class UniversalAnalyticsPlugin {
 	public trackMetric(key:number, value?:number, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Track a Screen (PageView) */
-	public trackView(screen:String, campaignUrl?:string, newSession?:boolean, successCallback?:Function, errorCallback?:Function):void;
+	public trackView(screen:string, campaignUrl?:string, newSession?:boolean, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Add a Custom Dimension */
-	public addCustomDimension(key:number, value:String, successCallback?:Function, errorCallback?:Function):void;
+	public addCustomDimension(key:number, value:string, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Track an Event */
-	public trackEvent(category:String, action:String, label?:String, value?:Number, newSession?:boolean, successCallback?:Function, errorCallback?:Function):void;
+	public trackEvent(category:string, action:string, label?:string, value?:number, newSession?:boolean, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Track an Exception
 		https://developers.google.com/analytics/devguides/collection/android/v3/exceptions */
-	public trackException(description:String, fatal:Boolean, successCallback?:Function, errorCallback?:Function):void;
+	public trackException(description:string, fatal:boolean, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Enable/disable automatic reporting of uncaught exceptions */
-	public enableUncaughtExceptionReporting(enable:Boolean, successCallback?:Function, errorCallback?:Function):void;
+	public enableUncaughtExceptionReporting(enable:boolean, successCallback?:Function, errorCallback?:Function):void;
 
 	/** Track User Timing (App Speed) */
-	public trackTiming(category:String, intervalInMilliseconds?:Number, name?:String, label?:String, successCallback?:Function, errorCallback?:Function):void;
+	public trackTiming(category:string, intervalInMilliseconds?:number, name?:string, label?:string, successCallback?:Function, errorCallback?:Function):void;
 
 	// Deprecated on 1.9.0 will be removed on next minor version (1.10.0).
 	/** Add a Transaction (Google Analytics e-Ccommerce Tracking)
 		https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce */
-	public addTransaction(transactionId:String, affiliation:String, revenue:Number, tax:Number, shipping:Number, currencyCode:String, successCallback?:Function, errorCallback?:Function):void;
+	public addTransaction(transactionId:string, affiliation:string, revenue:number, tax:number, shipping:number, currencyCode:string, successCallback?:Function, errorCallback?:Function):void;
 
 	// Deprecated on 1.9.0 will be removed on next minor version (1.10.0).
 	/** Add a Transaction Item (Ecommerce) */
-	public addTransactionItem(transactionId:String, name:String, sku:String, category:String, price:Number, quantity:Number, currencyCode:String, successCallback?:Function, errorCallback?:Function):void;
+	public addTransactionItem(transactionId:string, name:string, sku:string, category:string, price:number, quantity:number, currencyCode:string, successCallback?:Function, errorCallback?:Function):void;
 
-	public addImpression(screamName:String, product:Any, successCallback?:Function, errorCallback?:Function):void;
+	public addImpression(screamName:string, product:any, successCallback?:Function, errorCallback?:Function):void;
 
-	public productAction(screamName:String, product:Any, successCallback?:Function, errorCallback?:Function):void;
+	public productAction(screamName:string, product:any, successCallback?:Function, errorCallback?:Function):void;
 
-	public addPromotion(action:String, promotion:Any, label?:String, category?:String, successCallback?:Function, errorCallback?:Function):void;
+	public addPromotion(action:string, promotion:any, label?:string, category?:string, successCallback?:Function, errorCallback?:Function):void;
 
 }

--- a/windows/GoogleAnalyticsProxy.js
+++ b/windows/GoogleAnalyticsProxy.js
@@ -407,12 +407,8 @@ module.exports = {
             fail("Expected non empty string argument");
             return;
         }
-        if (args.length < 4 || args[3] === "") {
-            fail("Expected non empty string argument");
-            return;
-        }
 
-        var hit = GoogleAnalytics.HitBuilder.createCustomEvent(args[3], args[0], args[2] || null, 0);
+        var hit = GoogleAnalytics.HitBuilder.createCustomEvent(args[2], args[0], args[3] || null, 0);
 
         var promotion = new GoogleAnalytics.Ecommerce.Promotion();
         promotion.id = args[1].id;

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -193,13 +193,17 @@ promotion.name = "mypromo";
 promotion.position = "position";
 promotion.creative = "creative";
 */
-UniversalAnalyticsPlugin.prototype.addImpression = function(screamName, product, success, error) {
-  cordova.exec(success, error, 'UniversalAnalytics', 'addImpression', [screamName, product]);
+
+UniversalAnalyticsPlugin.prototype.addImpression = function(screen, product, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'addImpression', [screen, product]);
 };
 
-UniversalAnalyticsPlugin.prototype.productAction = function(screamName, product, productAction, success, error) {
-  cordova.exec(success, error, 'UniversalAnalytics', 'productAction', [screamName, product, productAction]);
+UniversalAnalyticsPlugin.prototype.productAction = function(screen, product, productAction, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'productAction', [screen, product, productAction]);
 };
+
+// RETHINK: swap label and category parameter positions?
+// (as an event hit is formed under the hood, category is mandatory while label is optional)
 
 UniversalAnalyticsPlugin.prototype.addPromotion = function(action, promotion, label, category, success, error) {
   cordova.exec(success, error, 'UniversalAnalytics', 'addPromotion', [action, promotion, label, category]);

--- a/www/analytics.js
+++ b/www/analytics.js
@@ -202,11 +202,8 @@ UniversalAnalyticsPlugin.prototype.productAction = function(screen, product, pro
   cordova.exec(success, error, 'UniversalAnalytics', 'productAction', [screen, product, productAction]);
 };
 
-// RETHINK: swap label and category parameter positions?
-// (as an event hit is formed under the hood, category is mandatory while label is optional)
-
-UniversalAnalyticsPlugin.prototype.addPromotion = function(action, promotion, label, category, success, error) {
-  cordova.exec(success, error, 'UniversalAnalytics', 'addPromotion', [action, promotion, label, category]);
+UniversalAnalyticsPlugin.prototype.addPromotion = function(action, promotion, category, label, success, error) {
+  cordova.exec(success, error, 'UniversalAnalytics', 'addPromotion', [action, promotion, category, label]);
 };
 
 //TODO add promotion impresion


### PR DESCRIPTION
Hi @victorsosa 

please have a look at this PR.
I added Windows 10 UWP support for enhanced ecommerce methods ```productAction()``` and ```addPromotion()```. (```addImpression()``` is currently not supported by the Windows SDK for GA..).
I found another bug in the Windows SDK for GA, taking the wrong data specifier for product quantity; so using this without my new PR at https://github.com/dotnet/windows-sdk-for-google-analytics/pull/28 could result in the productAction hit not being accepted by analytics backend..

I futhermore fixed some parameter types in the typescript definitions ("Any" has to be "any"). 
See also https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html on using primitive types over object types..

Please also have a thought on my rethink-comment in analytics.js..
