### PR TITLE
Fix for recent google play services update

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
   </platform>
 
   <platform name="android">
-    <framework src="com.google.android.gms:play-services-analytics:+" />
+    <framework src="com.google.android.gms:play-services-analytics:11.+" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="UniversalAnalytics">


### PR DESCRIPTION
version 12.0.0 https://developers.google.com/android/guides/releases is crashing APK builds with
> Error: more than one library with package name 'com.google.android.gms.license'