### PR TITLE
Automatic GoogleToolboxForMac pod install for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,6 +47,8 @@
     <framework src="AdSupport.framework" />
     <framework src="libz.dylib" />
     <framework src="libsqlite3.dylib" />
+
+    <framework src="GoogleToolboxForMac" type="podspec" spec="~> 2.1.4"/>
   </platform>
 
   <platform name="android">


### PR DESCRIPTION
This installs automatically required pod file and fixes error `ld: library not found for -lGoogleToolboxForMac`