### PR TITLE
nuget via lib file instead of manual install

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -114,10 +114,6 @@
     <config-file target="package.phone.appxmanifest" parent="/Package/Capabilities" versions=">=8.1.0" device-target="phone">
       <Capability Name="internetClientServer" />
     </config-file>
-
-    <info>
-      You need to install Windows SDK for Google Analytics™ (UWP.SDKforGoogleAnalytics.Native) via nuget package manager
-      and set target to either x86 or x64!
-    </info>
+	<lib-file src="UWP.SDKforGoogleAnalytics.Native, Version=1.5.2" />
   </platform>
 </plugin>


### PR DESCRIPTION
With lib-file the nuget package will be added to Cordova Windows automatically, no nuget package manager is needed