### PR TITLE
remove CampaignTrackingReceiver (deprecated on SDK31+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-google-analytics",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Google Universal Analytics Plugin",
   "cordova": {
     "id": "cordova-plugin-google-analytics",

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,12 +71,6 @@
         </intent-filter>
       </receiver>
       <service android:name="com.google.android.gms.analytics.AnalyticsService" android:enabled="true" android:exported="false"/>
-      <receiver android:name="com.google.android.gms.analytics.CampaignTrackingReceiver" android:enabled="true" android:exported="true">
-        <intent-filter>
-          <action android:name="com.android.vending.INSTALL_REFERRER" />
-        </intent-filter>
-      </receiver>
-      <service android:name="com.google.android.gms.analytics.CampaignTrackingService" android:enabled="true" android:exported="false"/>
     </config-file>
     <source-file src="android/UniversalAnalyticsPlugin.java" target-dir="src/com/danielcwilson/plugins/analytics" />
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@
 
   <platform name="android">
     <framework src="com.google.android.gms:play-services-analytics:$GMS_VERSION" />
-    <preference name="GMS_VERSION" default="11.0.1"/>
+    <preference name="GMS_VERSION" default="18.0.2"/>
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="UniversalAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-  xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-google-analytics" version="1.9.1">
+  xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-google-analytics" version="1.9.2">
   <engines>
     <engine name="cordova" version=">=3.0.0" />
   </engines>
@@ -65,7 +65,7 @@
     </config-file>
     <!-- Add support for devices without Google Play Services installed. -->
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <receiver android:name="com.google.android.gms.analytics.AnalyticsReceiver" android:exported="true" android:enabled="true">
+      <receiver android:name="com.google.android.gms.analytics.AnalyticsReceiver" android:enabled="true">
         <intent-filter>
           <action android:name="com.google.android.gms.analytics.ANALYTICS_DISPATCH" />
         </intent-filter>


### PR DESCRIPTION
1) remove CampaignTrackingReceiver (deprecated on SDK31+)
2) update analytics dependency to support SDK31+
3) bump version

tested on production and seems working for few days